### PR TITLE
Fix date range check in util and add tests

### DIFF
--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -13,17 +13,17 @@ describe("isWithinTwoWeeks", () => {
     vi.useRealTimers();
   });
 
-  it("returns true for a date within the last two weeks", () => {
+  it("直近2週間以内の日付ならtrueを返す", () => {
     const target = new Date("2024-06-25T00:00:00Z").toISOString();
     expect(isWithinTwoWeeks(target)).toBe(true);
   });
 
-  it("returns false for a date older than two weeks", () => {
+  it("2週間より前の日付ならfalseを返す", () => {
     const target = new Date("2024-06-10T00:00:00Z").toISOString();
     expect(isWithinTwoWeeks(target)).toBe(false);
   });
 
-  it("returns false for a future date", () => {
+  it("未来の日付ならfalseを返す", () => {
     const target = new Date("2024-07-10T00:00:00Z").toISOString();
     expect(isWithinTwoWeeks(target)).toBe(false);
   });

--- a/src/__tests__/util.spec.ts
+++ b/src/__tests__/util.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { isWithinTwoWeeks } from "@/util";
+
+describe("isWithinTwoWeeks", () => {
+  const now = new Date("2024-07-01T00:00:00Z");
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns true for a date within the last two weeks", () => {
+    const target = new Date("2024-06-25T00:00:00Z").toISOString();
+    expect(isWithinTwoWeeks(target)).toBe(true);
+  });
+
+  it("returns false for a date older than two weeks", () => {
+    const target = new Date("2024-06-10T00:00:00Z").toISOString();
+    expect(isWithinTwoWeeks(target)).toBe(false);
+  });
+
+  it("returns false for a future date", () => {
+    const target = new Date("2024-07-10T00:00:00Z").toISOString();
+    expect(isWithinTwoWeeks(target)).toBe(false);
+  });
+});

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -3,16 +3,19 @@ import { twMerge } from "tailwind-merge";
 
 export const cltw = (...inputs: (string | undefined)[]) => {
   return twMerge(clsx(inputs));
-}
+};
 
 export const isWithinTwoWeeks = (date: string) => {
   const targetDate = new Date(date);
-  const twoWeeksPrev = new Date(new Date().getTime() - 14 * 24 * 60 * 60 * 1000);
-  return targetDate >= twoWeeksPrev
-}
+  const twoWeeksPrev = new Date(
+    new Date().getTime() - 14 * 24 * 60 * 60 * 1000,
+  );
+  const now = new Date();
+  return targetDate >= twoWeeksPrev && targetDate <= now;
+};
 
 export const calcDiffYears = (date: string) => {
   const targetDate = new Date(date);
   const now = new Date();
   return now.getFullYear() - targetDate.getFullYear();
-}
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -5,12 +5,12 @@ export const cltw = (...inputs: (string | undefined)[]) => {
   return twMerge(clsx(inputs));
 };
 
+const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000;
+
 export const isWithinTwoWeeks = (date: string) => {
   const targetDate = new Date(date);
-  const twoWeeksPrev = new Date(
-    new Date().getTime() - 14 * 24 * 60 * 60 * 1000,
-  );
   const now = new Date();
+  const twoWeeksPrev = new Date(now.getTime() - TWO_WEEKS_MS);
   return targetDate >= twoWeeksPrev && targetDate <= now;
 };
 


### PR DESCRIPTION
## Summary
- fix `isWithinTwoWeeks` so that it excludes future dates
- add unit tests for `isWithinTwoWeeks`

## Testing
- `npx vitest run src/__tests__/util.spec.ts` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5417eb48324941b7acc6967b418