### PR TITLE
feat: 言語切り替えボタンの実装

### DIFF
--- a/src/components/Header/SPNav/NavDrower/index.tsx
+++ b/src/components/Header/SPNav/NavDrower/index.tsx
@@ -2,6 +2,7 @@
 import { Link } from 'next-view-transitions';
 
 import SocialMediaNav from "@/components/Header/SocialMediaNav";
+import LanguageSwitcher from "@/components/LanguageSwitcher";
 import ExternalLink from "@/components/UiParts/ExternalLink";
 import type { HeaderNavItem } from "@/types/header";
 
@@ -29,8 +30,13 @@ const NavDrower = ({ isOpen, items, locale, onClick }: NavDrowerProps) => {
               </Link>
           ))}
         </nav>
-        <div className="flex justify-center">
-          <SocialMediaNav locale={locale} />
+        <div className="flex flex-col items-center space-y-4">
+          <div className="px-4">
+            <LanguageSwitcher />
+          </div>
+          <div className="flex justify-center">
+            <SocialMediaNav locale={locale} />
+          </div>
         </div>
       </div>
         

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,6 +2,7 @@ import BlogTitle from "@/components/Header/BlogTitle";
 import LocaleAwareHeaderNav from "@/components/Header/LocaleAwareHeaderNav";
 import SPNav from "@/components/Header/SPNav";
 import SocialMediaNav from "@/components/Header/SocialMediaNav";
+import LanguageSwitcher from "@/components/LanguageSwitcher";
 import { SITE_TITLE } from "@/static/blogs";
 import { HEADER_NAV_ITEMS } from "@/static/header";
 
@@ -16,8 +17,11 @@ const Header = ({ locale }: HeaderProps) => {
         <div className="flex justify-between items-center mb-4 px-2 md:px-0">
           <div className="flex justify-between w-full">
             <BlogTitle title={SITE_TITLE} locale={locale} />
-            <div className="hidden md:block">
-              <SocialMediaNav locale={locale} />
+            <div className="flex items-center space-x-4">
+              <div className="hidden md:block">
+                <SocialMediaNav locale={locale} />
+              </div>
+              <LanguageSwitcher />
             </div>
           </div>
           <div className="block md:hidden">

--- a/src/components/LanguageSwitcher/index.tsx
+++ b/src/components/LanguageSwitcher/index.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useRouter, usePathname } from 'next/navigation';
+import { useLocale } from 'next-intl';
+import { useState, useEffect } from 'react';
+import { locales, type Locale } from '@/i18n/config';
+import { getAlternateLocaleUrl } from '@/lib/i18n-utils';
+
+const LOCALE_NAMES: Record<Locale, string> = {
+  ja: '日本語',
+  en: 'English'
+} as const;
+
+const LOCALE_FLAGS: Record<Locale, string> = {
+  ja: '🇯🇵',
+  en: '🇺🇸'
+} as const;
+
+export default function LanguageSwitcher() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentLocale = useLocale() as Locale;
+  const [isOpen, setIsOpen] = useState(false);
+
+  // 外部クリック時にドロップダウンを閉じる
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Element;
+      if (!target.closest('[data-language-switcher]')) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('click', handleClickOutside);
+      return () => document.removeEventListener('click', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  const handleLocaleChange = (newLocale: Locale) => {
+    if (newLocale === currentLocale) {
+      setIsOpen(false);
+      return;
+    }
+
+    // ロケール設定をlocalStorageに保存
+    localStorage.setItem('preferred-locale', newLocale);
+    
+    // サーバーサイド検出用にCookieにも保存
+    document.cookie = `preferred-locale=${newLocale}; path=/; max-age=31536000; SameSite=Lax`;
+    
+    // 対象ロケールで新しいURLを生成
+    const newUrl = getAlternateLocaleUrl(pathname, newLocale);
+    
+    // 新しいURLに遷移
+    router.push(newUrl);
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent, locale: Locale) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleLocaleChange(locale);
+    } else if (event.key === 'Escape') {
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative" data-language-switcher>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setIsOpen(!isOpen);
+          }
+        }}
+        className="flex items-center space-x-2 px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+        aria-label={`Current language: ${LOCALE_NAMES[currentLocale]}. Click to change language`}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+      >
+        <span className="text-lg" role="img" aria-hidden="true">
+          {LOCALE_FLAGS[currentLocale]}
+        </span>
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {currentLocale.toUpperCase()}
+        </span>
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-600 z-50"
+          role="listbox"
+          aria-label="Language options"
+        >
+          {locales.map((locale) => (
+            <button
+              key={locale}
+              onClick={() => handleLocaleChange(locale)}
+              onKeyDown={(e) => handleKeyDown(e, locale)}
+              className={`w-full flex items-center space-x-3 px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200 focus:outline-none focus:bg-gray-50 dark:focus:bg-gray-700 ${
+                locale === currentLocale
+                  ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
+                  : 'text-gray-700 dark:text-gray-300'
+              } ${locale === locales[0] ? 'rounded-t-md' : ''} ${
+                locale === locales[locales.length - 1] ? 'rounded-b-md' : ''
+              }`}
+              role="option"
+              aria-selected={locale === currentLocale}
+              tabIndex={0}
+            >
+              <span className="text-lg" role="img" aria-hidden="true">
+                {LOCALE_FLAGS[locale]}
+              </span>
+              <div className="flex-1">
+                <div className="text-sm font-medium">{LOCALE_NAMES[locale]}</div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  {locale.toUpperCase()}
+                </div>
+              </div>
+              {locale === currentLocale && (
+                <svg
+                  className="w-4 h-4 text-blue-600 dark:text-blue-400"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/locale.ts
+++ b/src/hooks/locale.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useLocale } from 'next-intl';
+import { type Locale } from '@/i18n/config';
+
+export const useLocalePreference = () => {
+  const currentLocale = useLocale() as Locale;
+  const [preferredLocale, setPreferredLocale] = useState<Locale>(currentLocale);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    
+    const saved = localStorage.getItem('preferred-locale') as Locale | null;
+    if (saved) {
+      setPreferredLocale(saved);
+    }
+  }, []);
+
+  const saveLocalePreference = (locale: Locale) => {
+    if (typeof window === 'undefined') return;
+    
+    localStorage.setItem('preferred-locale', locale);
+    setPreferredLocale(locale);
+  };
+
+  const getPreferredLocale = (): Locale | null => {
+    if (typeof window === 'undefined') return null;
+    
+    return localStorage.getItem('preferred-locale') as Locale | null;
+  };
+
+  return {
+    preferredLocale,
+    saveLocalePreference,
+    getPreferredLocale,
+    currentLocale
+  };
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,9 +16,15 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/404', request.url))
   }
 
-  // ルートパスを処理 - デフォルトlocaleにリダイレクト
+  // ルートパスを処理 - 保存されたlocale設定またはデフォルトlocaleにリダイレクト
   if (pathname === '/') {
-    return NextResponse.redirect(new URL(`/${routing.defaultLocale}`, request.url));
+    // Check for preferred locale in cookies
+    const preferredLocale = request.cookies.get('preferred-locale')?.value;
+    const targetLocale = preferredLocale && routing.locales.includes(preferredLocale as any) 
+      ? preferredLocale 
+      : routing.defaultLocale;
+    
+    return NextResponse.redirect(new URL(`/${targetLocale}`, request.url));
   }
 
   // pathnameにlocaleが含まれているかチェック


### PR DESCRIPTION
- ナビゲーションバーに言語切り替えUIを追加
- ドロップダウン形式でロケール選択が可能
- LocalStorageとCookieで設定を永続化
- モバイル/デスクトップ両対応
- アクセシビリティ対応（ARIA、キーボード操作）
- サーバーサイドでCookie設定を考慮

🤖 Generated with [Claude Code](https://claude.ai/code)