### PR TITLE
feat: 英語版ブログAPI対応とフル国際化実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,33 @@
 # CLAUDE.md
-
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Commands
+## Development Guidelines
 
+### Code Style and Conventions
+1. **Comments**: All code comments MUST be written in Japanese (日本語でコメントを記述)
+2. **TypeScript Types**: Use `type` instead of `interface` except where `interface` is absolutely required (e.g., declaration merging, extending interfaces)
+   ```typescript
+   // ✅ Good - type を使用
+   type User = {
+     id: string;
+     name: string;
+   };
+   
+   // ❌ Avoid - interface は必要な場合のみ
+   interface User {
+     id: string;
+     name: string;
+   }
+   ```
+
+### Development Process
+1. **Task Validation**: After completing each task, verify that the previously established approach remains correct
+2. **Build Verification**: Always run a build at the end of development work and fix any errors before completion
+   ```bash
+   npm run build  # 必ずビルドを実行してエラーを確認
+   ```
+
+## Commands
 ### Development
 ```bash
 npm run dev          # Start development server on port 3006
@@ -32,11 +56,9 @@ npm run update-rss   # Update RSS feed data
 ```
 
 ## Architecture Overview
-
 This is a Next.js 14 blog application using App Router, TypeScript, and TailwindCSS. Content is managed through microCMS (headless CMS) with additional integration from Zenn.
 
 ### Key Architectural Patterns
-
 1. **Server Components by Default**: Most components are React Server Components. Client components are explicitly marked with 'use client' and typically found in:
    - `ClientLayout` - Manages client-side theme state
    - Interactive UI components (modals, accordions, etc.)
@@ -51,7 +73,6 @@ This is a Next.js 14 blog application using App Router, TypeScript, and Tailwind
 4. **State Management**: Minimal client state using React Context (theme only). Most state is derived from URL params.
 
 ### Environment Setup
-
 Required environment variables:
 ```
 MICROCMS_API_KEY=your_api_key
@@ -59,21 +80,30 @@ MICROCMS_SERVICE_DOMAIN=your_domain
 ```
 
 ### Testing Strategy
-
 - **Unit Tests**: Components with complex logic, located in `__tests__` directories
 - **E2E Tests**: Full user flows in `/e2e` directory covering navigation, SEO, accessibility, and security
 - **Component Tests**: Storybook stories alongside components for visual testing
 
 ### Key Directories
-
 - `/src/app/` - Next.js pages and API routes
 - `/src/components/` - React components organized by feature
 - `/src/lib/microcms.ts` - Core API client and data fetching
 - `/src/components/ArticleBody/RichEditor/` - Content rendering system
 
 ### Important Considerations
-
 1. **Image Optimization**: All images use Next.js Image component with blur placeholders generated from microCMS
 2. **SEO**: Metadata and OpenGraph images are generated per page, JSON-LD structured data included
 3. **Performance**: Uses standalone mode for deployment, view transitions API for smooth navigation
 4. **Content Features**: Supports code syntax highlighting, Twitter embeds, Amazon link cards, and custom HTML areas
+
+## Development Workflow
+1. Make changes following the code style guidelines above
+2. Validate your approach after each significant change
+3. Test your changes locally: `npm run dev`
+4. Run linter: `npm run lint`
+5. Run tests: `npm run test`
+6. **Final step**: Run production build and fix any errors
+   ```bash
+   npm run build
+   # エラーがあれば修正してから完了
+   ```

--- a/locales/en.json
+++ b/locales/en.json
@@ -27,7 +27,25 @@
     "noPostsFound": "No posts found",
     "allCategories": "All",
     "zennArticles": "Zenn Articles",
-    "page": "Page"
+    "page": "Page",
+    "searchConditions": "Search conditions", 
+    "search": "Search",
+    "resetSearchConditions": "Reset search conditions",
+    "zennSearchNotSupported": "※ Zenn articles don't support search",
+    "showMore": "Show more",
+    "oldArticleNotice": "This article was published <years>{diffYear}</years> years ago",
+    "requestCorrection": "Request Correction",
+    "previousArticle": "Previous Article",
+    "nextArticle": "Next Article",
+    "shareOnX": "Share on X",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "copiedAriaLabel": "Copied",
+    "copyCodeAriaLabel": "Copy code",
+    "wrapText": "Wrap",
+    "unwrapText": "Unwrap",
+    "promotionalContent": "This article contains promotional content",
+    "issueTemplate": "Target page: {url}\\n\\n■ Fix location\\n\\n■ Reason for fix\\n\\n■ Improvement suggestions\\n\\n■ Other\\n"
   },
   "pagination": {
     "previous": "Previous",
@@ -37,5 +55,41 @@
   "footer": {
     "copyright": "© {year} Ryota's Web Engineer Blog",
     "allRightsReserved": "All rights reserved."
+  },
+  "error": {
+    "notFound": {
+      "title": "Page Not Found",
+      "message": "The page you are looking for could not be found.",
+      "backToHome": "Back to Home"
+    },
+    "serverError": {
+      "title": "Server Error",
+      "message": "An internal server error occurred.",
+      "backToHome": "Back to Home"
+    },
+    "noContent": {
+      "message": "No content available to display.",
+      "backToHome": "Back to Home"
+    }
+  },
+  "categories": {
+    "python": "Python",
+    "typescript": "TypeScript",
+    "css": "CSS", 
+    "next_js": "Next.js",
+    "release_notes": "Release Notes",
+    "aws": "AWS",
+    "review": "Review",
+    "zakki": "Daily",
+    "react": "React",
+    "openai_api": "OpenAI API",
+    "gadget": "Gadget",
+    "tailwindcss": "TailwindCSS",
+    "ui_parts": "UI",
+    "programming": "Programming",
+    "career": "Career",
+    "life_hack": "LifeHack",
+    "news": "News",
+    "terraform": "Terraform"
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -28,7 +28,25 @@
     "allCategories": "すべて",
     "zennArticles": "Zenn記事",
     "mostReadArticles": "最も読まれている記事",
-    "page": "ページ"
+    "page": "ページ",
+    "searchConditions": "検索条件",
+    "search": "検索",
+    "resetSearchConditions": "検索条件をリセット",
+    "zennSearchNotSupported": "※ Zennの記事は検索非対応",
+    "showMore": "もっと見る",
+    "oldArticleNotice": "こちらは <years>{diffYear}</years> 年前に公開された記事です",
+    "requestCorrection": "修正をリクエストする",
+    "previousArticle": "前の記事",
+    "nextArticle": "次の記事",
+    "shareOnX": "Xにシェア",
+    "copy": "コピー",
+    "copied": "コピーしました!",
+    "copiedAriaLabel": "コピー済み",
+    "copyCodeAriaLabel": "コードをコピー",
+    "wrapText": "折り返し",
+    "unwrapText": "折り返しなし",
+    "promotionalContent": "こちらの記事にはプロモーションを含みます",
+    "issueTemplate": "対象ページ: {url}\\n\\n■修正箇所\\n\\n■修正の理由\\n\\n■改善提案\\n\\n■その他\\n"
   },
   "pagination": {
     "previous": "前へ",
@@ -38,5 +56,41 @@
   "footer": {
     "copyright": "© {year} りょうたのWebエンジニアブログ",
     "allRightsReserved": "All rights reserved."
+  },
+  "error": {
+    "notFound": {
+      "title": "ページが見つかりません",
+      "message": "お探しのページが見つかりませんでした。",
+      "backToHome": "トップページに戻る"
+    },
+    "serverError": {
+      "title": "サーバーエラー",
+      "message": "サーバー内部のエラーが発生しました。",
+      "backToHome": "トップページに戻る"
+    },
+    "noContent": {
+      "message": "表示できるコンテンツがありません。",
+      "backToHome": "トップページに戻る"
+    }
+  },
+  "categories": {
+    "python": "Python",
+    "typescript": "TypeScript", 
+    "css": "CSS",
+    "next_js": "Next.js",
+    "release_notes": "Release Notes",
+    "aws": "AWS",
+    "review": "レビュー",
+    "zakki": "雑記",
+    "react": "React",
+    "openai_api": "OpenAI API",
+    "gadget": "ガジェット",
+    "tailwindcss": "TailwindCSS",
+    "ui_parts": "UI",
+    "programming": "プログラミング",
+    "career": "Career",
+    "life_hack": "LifeHack",
+    "news": "時事",
+    "terraform": "Terraform"
   }
 }

--- a/src/app/[locale]/about/layout.tsx
+++ b/src/app/[locale]/about/layout.tsx
@@ -13,9 +13,10 @@ interface AboutLayoutProps {
 
 export async function generateMetadata({ params: { locale } }: AboutLayoutProps): Promise<Metadata> {
   const t = await getTranslations({ locale, namespace: 'metadata' });
+  const tNav = await getTranslations({ locale, namespace: 'navigation' });
   
   return {
-    title: 'About',
+    title: tNav('about'),
     description: t('siteDescription'),
     metadataBase: new URL(baseURL)
   };

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,7 +1,7 @@
 import SocialMediaIcons from "@/components/Header/SocialMediaIcons";
 import Chip from "@/components/UiParts/Chip";
 import ImageWithBlur from "@/components/UiParts/ImageWithBlur";
-import { AUTHOR_DESCRIPTION, AUTHOR_NAME } from "@/static/blogs";
+import { AUTHOR_DESCRIPTION, AUTHOR_DESCRIPTION_EN, AUTHOR_NAME, AUTHOR_NAME_EN } from "@/static/blogs";
 
 interface AboutPageProps {
   params: {
@@ -10,6 +10,9 @@ interface AboutPageProps {
 }
 
 const Page = ({ params: { locale } }: AboutPageProps) => {
+  const authorName = locale === 'en' ? AUTHOR_NAME_EN : AUTHOR_NAME;
+  const authorDescription = locale === 'en' ? AUTHOR_DESCRIPTION_EN : AUTHOR_DESCRIPTION;
+  
   return (
     <article className="flex h-full min-h-[600px] w-full flex-grow flex-col items-center justify-center gap-8 border-2 border-gray-200 bg-white px-8 md:flex-row md:justify-between dark:border-gray-600 dark:bg-black">
       <div className="flex flex-col items-start space-y-8">
@@ -18,17 +21,17 @@ const Page = ({ params: { locale } }: AboutPageProps) => {
           classes="bg-light dark:bg-primary py-1 px-3 text-txt-base"
         />
         <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl md:text-6xl dark:text-gray-300">
-          {AUTHOR_NAME}
+          {authorName}
         </h1>
         <p className="max-w-[600px] text-gray-500 md:text-xl/relaxed lg:text-base/relaxed xl:text-xl/relaxed dark:text-gray-400">
-          {AUTHOR_DESCRIPTION}
+          {authorDescription}
         </p>
         <SocialMediaIcons locale={locale} />
       </div>
       <figure>
         <ImageWithBlur
           src="/author.png"
-          alt={AUTHOR_NAME}
+          alt={authorName}
           className="mx-auto block aspect-square w-[200px] overflow-hidden rounded-full object-cover shadow-2xl md:w-[400px]"
           width={400}
           height={400}

--- a/src/app/[locale]/blogs/[category]/[blogId]/opengraph-image.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 import fs from "fs";
 import path from "path";
 
-import { getBlogById } from "@/lib/microcms";
+import { getBlogByIdByLocale } from "@/lib/microcms";
 import { AUTHOR_NAME } from "@/static/blogs";
 
 export const size = {
@@ -15,14 +15,14 @@ export const contentType = "image/png";
 export default async function Image({
   params,
 }: {
-  params: { blogId: string };
+  params: { locale: string; blogId: string };
 }) {
   const fontData = await fs.readFileSync(
     path.join(process.cwd(), "public/KosugiMaru-Regular.ttf"),
   );
 
   const blogId = params.blogId;
-  const data = await getBlogById(blogId, { fields: "title" });
+  const data = await getBlogByIdByLocale(params.locale, blogId, { fields: "title" });
 
   return new ImageResponse(
     (

--- a/src/app/[locale]/blogs/[category]/[blogId]/twitter-image.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/twitter-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-import { getBlogById } from "@/lib/microcms";
+import { getBlogByIdByLocale } from "@/lib/microcms";
 import { AUTHOR_NAME } from "@/static/blogs";
 
 export const size = {
@@ -13,10 +13,10 @@ export const contentType = "image/png";
 export default async function Image({
   params,
 }: {
-  params: { blogId: string };
+  params: { locale: string; blogId: string };
 }) {
   const blogId = params.blogId;
-  const data = await getBlogById(blogId, { fields: "title" });
+  const data = await getBlogByIdByLocale(params.locale, blogId, { fields: "title" });
   return new ImageResponse(
     (
       <div

--- a/src/app/[locale]/blogs/[category]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page.tsx
@@ -2,21 +2,19 @@ import { Suspense } from "react";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import dynamic from "next/dynamic";
 import { getTranslations } from 'next-intl/server';
 
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
 import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
+import ZennArticleList from "@/components/ZennArticleList";
 import { generateQuery } from "@/lib";
 import { BLOG_TYPE_QUERY, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY, CATEGORY_MAPED_NAME, CATEGORY_MAPED_ID } from "@/static/blogs";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
 import type { MappedKeyLiteralType } from "@/types/microcms";
 import type { BlogTypeKeyLIteralType } from "@/types";
 import { locales } from '@/i18n/config';
-
-const ZennArticleList = dynamic(() => import("@/components/ZennArticleList"));
 
 export async function generateStaticParams() {
   const params = [];
@@ -118,15 +116,15 @@ const Page = ({ params, searchParams }: PageProps) => {
           </div>
           {blogType === "zenn"
             ?
-            <ZennArticleList />
+            <ZennArticleList locale={params.locale} />
             :
             <Suspense fallback={<Skelton />}>
-              <ArticleList query={query} blogType={blogType} page={page} basePath={`/${params.locale}/blogs/${params.category}`} />
+              <ArticleList query={query} blogType={blogType} page={page} basePath={`/${params.locale}/blogs/${params.category}`} locale={params.locale} />
             </Suspense>
           }
         </div>
       </div>
-      <SideNav />
+      <SideNav locale={params.locale} />
     </>
   );
 };

--- a/src/app/[locale]/blogs/page.tsx
+++ b/src/app/[locale]/blogs/page.tsx
@@ -1,20 +1,18 @@
 import { Suspense } from "react";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
-import dynamic from "next/dynamic";
 import { getTranslations } from 'next-intl/server';
 
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
 import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
+import ZennArticleList from "@/components/ZennArticleList";
 import { generateQuery } from "@/lib";
 import { BLOG_TYPE_QUERY, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY } from "@/static/blogs";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
 import type { MappedKeyLiteralType } from "@/types/microcms";
 import type { BlogTypeKeyLIteralType } from "@/types";
-
-const ZennArticleList = dynamic(() => import("@/components/ZennArticleList"));
 
 interface PageProps {
   params: {
@@ -99,15 +97,15 @@ const Page = ({ params: { locale }, searchParams }: PageProps) => {
           </div>
           {blogType === "zenn"
             ?
-            <ZennArticleList />
+            <ZennArticleList locale={locale} />
             :
             <Suspense fallback={<Skelton />}>
-              <ArticleList query={query} blogType={blogType} page={page} />
+              <ArticleList query={query} blogType={blogType} page={page} locale={locale} />
             </Suspense>
           }
         </div>
       </div>
-      <SideNav />
+      <SideNav locale={locale} />
     </>
   );
 }

--- a/src/app/[locale]/blogs/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/page/[page]/page.tsx
@@ -9,16 +9,18 @@ import Skelton from "@/components/ArticleList/skelton";
 import SideNav from "@/components/SideNav";
 import { generateQuery } from "@/lib";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
-import { getBlogList } from "@/lib/microcms";
+import { getBlogListByLocale } from "@/lib/microcms";
 import { PER_PAGE } from "@/static/blogs";
 import { locales } from '@/i18n/config';
 
 export async function generateStaticParams() {
-  const data = await getBlogList({ limit: 1 });
-  const totalPages = Math.ceil(data.totalCount / PER_PAGE);
-  
   const params = [];
+  
   for (const locale of locales) {
+    // 各ロケールごとにデータを取得
+    const data = await getBlogListByLocale(locale, { limit: 1 });
+    const totalPages = Math.ceil(data.totalCount / PER_PAGE);
+    
     // ページ2以降のパラメータを生成（ページ1は/[locale]/blogsにある）
     for (let i = 2; i <= totalPages; i++) {
       params.push({
@@ -62,7 +64,7 @@ const Page = async ({ params }: { params: { locale: string; page: string } }) =>
   }
   
   // ページが存在するかチェック
-  const data = await getBlogList({ limit: 1 });
+  const data = await getBlogListByLocale(params.locale, { limit: 1 });
   const totalPages = Math.ceil(data.totalCount / PER_PAGE);
   
   if (pageNum > totalPages) {
@@ -88,11 +90,11 @@ const Page = async ({ params }: { params: { locale: string; page: string } }) =>
             </div>
           </div>
           <Suspense fallback={<Skelton />}>
-            <ArticleList query={query} blogType={blogType} page={params.page} basePath={`/${params.locale}/blogs`} />
+            <ArticleList query={query} blogType={blogType} page={params.page} basePath={`/${params.locale}/blogs`} locale={params.locale} />
           </Suspense>
         </div>
       </div>
-      <SideNav />
+      <SideNav locale={params.locale} />
     </>
   );
 };

--- a/src/app/[locale]/blogs/zenn/page.tsx
+++ b/src/app/[locale]/blogs/zenn/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({ params: { locale } }: ZennPageProps): P
   };
 }
 
-const ZennPage = () => {
+const ZennPage = ({ params }: ZennPageProps) => {
   return (
     <>
       <div className="w-full lg:w-[calc(100%_-_300px)] flex flex-col justify-between px-2 md:px-0">
@@ -31,10 +31,10 @@ const ZennPage = () => {
               <BlogTypeTabs blogType="zenn" />
             </div>
           </div>
-          <ZennArticleList />
+          <ZennArticleList locale={params.locale} />
         </div>
       </div>
-      <SideNav />
+      <SideNav locale={params.locale} />
     </>
   );
 };

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,34 +1,11 @@
 import type { Metadata } from "next";
-import { Link } from 'next-view-transitions'
-import Image from "next/image";
-
-import Footer from "@/components/Footer";
-import Header from "@/components/Header";
+import NotFoundContent from "@/components/NotFoundContent";
 
 export const metadata: Metadata = {
-  title: "Not Found"
+  title: "ページが見つかりません"
 };
 
 const Page = () => {
-  return (
-    <>
-      <Header />
-      <main className="flex-grow flex flex-col md:flex-row container mx-auto gap-4 my-4 h-full px-2">
-        <div className="flex-grow flex w-full flex-col items-center justify-center bg-white p-4 dark:bg-gray-900 border-2 border-gray-200 dark:border-gray-600">
-          <div className="flex flex-col items-center justify-center space-y-4">
-          <Image src="/404.png" alt="No contents" width={300} height={300} sizes="100vw" style={{ width: '50%', height: 'auto' }} />
-            <h1 className="text-8xl font-bold text-gray-800 dark:text-gray-200">404</h1>
-            <p className="text-lg font-medium text-gray-600 dark:text-gray-400">
-              お探しのページが見つかりませんでした。
-            </p>
-            <Link href="/blogs" className="text-base-color border-2 border-base-color px-4 py-2 hover:bg-base-color hover:text-white hover:border-base-color transition duration-200">
-              トップページに戻る
-            </Link>
-          </div>
-        </div>
-      </main>
-      <Footer />
-    </>
-  )
+  return <NotFoundContent />;
 }
 export default Page

--- a/src/components/AdRevenueLabel/index.tsx
+++ b/src/components/AdRevenueLabel/index.tsx
@@ -1,4 +1,10 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
 const AdRevenueLabel = () => {
+  const t = useTranslations('blog');
+  
   return (
     <div className="flex items-center text-txt-base  bg-gray-50 dark:bg-gray-600  p-4 w-fit">
       <svg
@@ -35,7 +41,7 @@ const AdRevenueLabel = () => {
           ></path>
         </g>
       </svg>
-      <span className="ml-2 text-md dark:text-gray-300">こちらの記事にはプロモーションを含みます</span>
+      <span className="ml-2 text-md dark:text-gray-300">{t('promotionalContent')}</span>
     </div>
   );
 };

--- a/src/components/ArticleBody/BottomCard/index.tsx
+++ b/src/components/ArticleBody/BottomCard/index.tsx
@@ -1,7 +1,10 @@
-import { AUTHOR_DESCRIPTION, AUTHOR_NAME } from "@/static/blogs";
+import { AUTHOR_DESCRIPTION, AUTHOR_DESCRIPTION_EN, AUTHOR_NAME, AUTHOR_NAME_EN } from "@/static/blogs";
 import Image from "next/image";
+import { useLocale } from 'next-intl';
 
 const BottomCard = () => {
+  const locale = useLocale();
+  
   return (
     <>
       <div className="mx-6 flex shrink-0 items-center justify-center">
@@ -15,9 +18,11 @@ const BottomCard = () => {
         />
       </div>
       <div>
-        <p className="text-3xl font-bold dark:text-gray-300">{AUTHOR_NAME}</p>
+        <p className="text-3xl font-bold dark:text-gray-300">
+          {locale === 'en' ? AUTHOR_NAME_EN : AUTHOR_NAME}
+        </p>
         <p className="mx-1 mt-4 text-gray-500 dark:text-gray-400">
-          {AUTHOR_DESCRIPTION}
+          {locale === 'en' ? AUTHOR_DESCRIPTION_EN : AUTHOR_DESCRIPTION}
         </p>
       </div>
     </>

--- a/src/components/ArticleBody/CategoryTag.tsx
+++ b/src/components/ArticleBody/CategoryTag.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Link } from 'next-view-transitions';
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import Chip from '@/components/UiParts/Chip';
 
 type CategoryTagProps = {
@@ -11,11 +11,40 @@ type CategoryTagProps = {
 
 const CategoryTag = ({ name, index }: CategoryTagProps) => {
   const locale = useLocale();
+  const t = useTranslations('categories');
+  
+  // カテゴリ名から対応するIDを取得（逆引き）
+  const getCategoryId = (categoryName: string) => {
+    const categoryMap: { [key: string]: string } = {
+      'Python': 'python',
+      'TypeScript': 'typescript',
+      'CSS': 'css',
+      'Next.js': 'next_js',
+      'Release Notes': 'release_notes',
+      'AWS': 'aws',
+      'レビュー': 'review',
+      '雑記': 'zakki',
+      'React': 'react',
+      'OpenAI API': 'openai_api',
+      'ガジェット': 'gadget',
+      'TailwindCSS': 'tailwindcss',
+      'UI': 'ui_parts',
+      'プログラミング': 'programming',
+      'Career': 'career',
+      'LifeHack': 'life_hack',
+      '時事': 'news',
+      'Terraform': 'terraform'
+    };
+    return categoryMap[categoryName] || 'programming';
+  };
+  
+  const categoryId = getCategoryId(name);
+  const localizedName = t(categoryId);
   
   return (
     <li key={index} className="block cursor-pointer">
       <Link href={`/${locale}/blogs?category=${name}`}>
-        <Chip label={`#${name}`} classes="bg-gray-200 dark:bg-gray-600 dark:text-gray-300 px-3 py-2 text-sm text-txt-base hover:opacity-60" />
+        <Chip label={`#${localizedName}`} classes="bg-gray-200 dark:bg-gray-600 dark:text-gray-300 px-3 py-2 text-sm text-txt-base hover:opacity-60" />
       </Link>
     </li>
   );

--- a/src/components/ArticleBody/LocaleAwareShare.tsx
+++ b/src/components/ArticleBody/LocaleAwareShare.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import XShareButton from "@/components/UiParts/XShareButton";
 import { baseURL } from "@/config";
 
@@ -12,6 +12,7 @@ type LocaleAwareShareProps = {
 
 const LocaleAwareShare = ({ categoryId, blogId, title }: LocaleAwareShareProps) => {
   const locale = useLocale();
+  const t = useTranslations('blog');
   
   return (
     <div className="fixed z-50 bottom-4 left-4">
@@ -20,7 +21,7 @@ const LocaleAwareShare = ({ categoryId, blogId, title }: LocaleAwareShareProps) 
         text={title}
         classes="bg-gray-700 text-white p-2 rounded-lg shadow-lg hover:bg-gray-600 transition-colors duration-300 h-12 w-auto flex items-center justify-center"
       >
-        Xにシェア
+        {t('shareOnX')}
       </XShareButton>
     </div>
   );

--- a/src/components/ArticleBody/PrevAndNextBlogNav/PrevAndNextNavItem/index.tsx
+++ b/src/components/ArticleBody/PrevAndNextBlogNav/PrevAndNextNavItem/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Link } from "next-view-transitions";
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 import type { BlogsContentType } from "@/types/microcms";
 import { cltw } from "@/util";
@@ -14,12 +14,13 @@ type PrevAndNextBlogNavItemProps = {
 
 const PrevAndNextBlogNavItem = ({ role, data }: PrevAndNextBlogNavItemProps) => {
   const locale = useLocale();
+  const t = useTranslations('blog');
   const displayTime = data.publishedAt || data.updatedAt;
   const categoryId = getPrimaryCategoryId(data);
   
   return (
     <Link href={`/${locale}/blogs/${categoryId}/${data.id}`} className={cltw("max-w-1/2 py-4 transition text-gray-400 dark:text-gray-500 underline underline-offset-4 hover:opacity-70 hover:text-base-color hover:no-underline", role === "prev" ? "text-left" : "text-right")}>
-      <span>{role === "prev" ? "前の記事" : "次の記事"}</span><br className="inline sm:hidden" />
+      <span>{role === "prev" ? t('previousArticle') : t('nextArticle')}</span><br className="inline sm:hidden" />
       <time dateTime={displayTime.split('T')[0]}>({displayTime.split('T')[0]})</time><br />
       <span className="line-clamp-2 sm:line-clamp-1">{data.title}</span>
     </Link>

--- a/src/components/ArticleBody/PrevAndNextBlogNav/index.tsx
+++ b/src/components/ArticleBody/PrevAndNextBlogNav/index.tsx
@@ -1,13 +1,14 @@
 import PrevAndNextBlogNavItem from "@/components/ArticleBody/PrevAndNextBlogNav/PrevAndNextNavItem";
-import { getPrevAndNextBlog } from "@/lib/microcms";
+import { getPrevAndNextBlogByLocale } from "@/lib/microcms";
 import type { BlogsContentType } from "@/types/microcms";
 
 type PrevAndNextBlogNavProps = {
   currentBlogData: BlogsContentType
+  locale: string
 }
 
-const PrevAndNextBlogNav = async ({ currentBlogData }: PrevAndNextBlogNavProps) => {
-  const { prevBlogData, nextBlogData } = await getPrevAndNextBlog(currentBlogData);
+const PrevAndNextBlogNav = async ({ currentBlogData, locale }: PrevAndNextBlogNavProps) => {
+  const { prevBlogData, nextBlogData } = await getPrevAndNextBlogByLocale(locale, currentBlogData);
   return (
     <nav className="mt-4 grid grid-cols-2 divide-x-4 divide-white dark:divide-black">
       {prevBlogData ? <PrevAndNextBlogNavItem role="prev" data={prevBlogData} /> : <div className="max-w-1/2 py-4" />}

--- a/src/components/ArticleBody/RichEditor/Code/CopyButton/index.tsx
+++ b/src/components/ArticleBody/RichEditor/Code/CopyButton/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { useTranslations } from 'next-intl';
 import Tooltip from "../Tooltip";
 import { CODE_BLOCK_STYLES, ICONS, TIMING } from "../constants";
 
@@ -10,6 +11,7 @@ type CopyButtonProps = {
 };
 
 const CopyButton = ({ text, className }: CopyButtonProps) => {
+  const t = useTranslations('blog');
   const [isCopied, setIsCopied] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
@@ -49,7 +51,7 @@ const CopyButton = ({ text, className }: CopyButtonProps) => {
     setIsHovered(false);
   }, []);
 
-  const tooltipText = isCopied ? "コピーしました!" : "コピー";
+  const tooltipText = isCopied ? t('copied') : t('copy');
 
   return (
     <button
@@ -58,7 +60,7 @@ const CopyButton = ({ text, className }: CopyButtonProps) => {
       onClick={copyToClipboard}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      aria-label={isCopied ? "コピー済み" : "コードをコピー"}
+      aria-label={isCopied ? t('copiedAriaLabel') : t('copyCodeAriaLabel')}
       title={tooltipText}
     >
       <svg

--- a/src/components/ArticleBody/RichEditor/Code/WrapToggleButton/index.tsx
+++ b/src/components/ArticleBody/RichEditor/Code/WrapToggleButton/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { useTranslations } from 'next-intl';
 import Tooltip from "../Tooltip";
 import { CODE_BLOCK_STYLES, ICONS } from "../constants";
 
@@ -15,6 +16,7 @@ const WrapToggleButton = ({
   defaultWrapped = false,
   className 
 }: WrapToggleButtonProps) => {
+  const t = useTranslations('blog');
   const [isWrapped, setIsWrapped] = useState(defaultWrapped);
   const [isHovered, setIsHovered] = useState(false);
 
@@ -32,7 +34,7 @@ const WrapToggleButton = ({
     setIsHovered(false);
   }, []);
 
-  const tooltipText = isWrapped ? "折り返しなし" : "折り返し";
+  const tooltipText = isWrapped ? t('unwrapText') : t('wrapText');
 
   return (
     <button

--- a/src/components/ArticleBody/TOCList/index.tsx
+++ b/src/components/ArticleBody/TOCList/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+import { useTranslations } from 'next-intl';
 import TOCItem from "@/components/ArticleBody/TOCList/TOCItem"
 import type { TOCAssetsType } from "@/types"
 
@@ -6,10 +8,11 @@ type TOCListProps = {
 }
 
 const TOCList = ({ data }: TOCListProps) => {
+  const t = useTranslations('blog');
   return (
     <div className="hover:bg-gray-50 dark:hover:bg-gray-600 transition duration-200 rounded-md hover:shadow-lg">
       <details>
-        <summary className="py-6 px-4 text-2xl dark:text-gray-300 font-semibold w-full cursor-pointer marker:text-secondary">目次</summary>
+        <summary className="py-6 px-4 text-2xl dark:text-gray-300 font-semibold w-full cursor-pointer marker:text-secondary">{t('tableOfContents')}</summary>
         <nav className="ml-8 mr-1 md:ml-12 md:mr-12 pb-10">
           <ol className="space-y-8 list-decimal">
             {data.map(({ id, text, subList }) => (

--- a/src/components/ArticleBody/index.tsx
+++ b/src/components/ArticleBody/index.tsx
@@ -21,9 +21,10 @@ const AmazonLinkCard = dynamic(() => import('@/components/ArticleBody/RichEditor
 
 type ArticleBodyProps = {
   data: BlogsContentType
+  locale: string
 }
 
-const ArticleBody = ({ data }: ArticleBodyProps) => {
+const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
   const joindedHTML = data.body.map((body) => {
     if (body.fieldId === 'richEditor') {
       return body.richEditor
@@ -94,7 +95,7 @@ const ArticleBody = ({ data }: ArticleBodyProps) => {
         })}
       </div>
         <IssueButton currentPath={`https://ryotablog.com/ja/blogs/${categoryId}/${data.id}`} />
-        <PrevAndNextBlogNav currentBlogData={data} />
+        <PrevAndNextBlogNav currentBlogData={data} locale={locale} />
         <aside className='flex flex-col-reverse md:flex-row gap-8 md:gap-4 mx-0.5 border-t dark:border-t-[#333] py-10'>
           <BottomCard />
         </aside>

--- a/src/components/ArticleList/ArticleCard/index.tsx
+++ b/src/components/ArticleList/ArticleCard/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Link } from 'next-view-transitions'
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { BlogsContentType } from "@/types/microcms"
 import NewLabel from "@/components/UiParts/NewLabel"
@@ -23,6 +23,7 @@ type ArticleCardProps = {
 
 const ArticleCard = ({ data, index }: ArticleCardProps) => {
   const locale = useLocale();
+  const t = useTranslations('blog');
   const categoryId = getPrimaryCategoryId(data);
   const blogPath = getBlogPath(locale, categoryId, data.id);
   
@@ -37,7 +38,7 @@ const ArticleCard = ({ data, index }: ArticleCardProps) => {
             <Link href={blogPath} className="mt-4 text-md md:text-xs md:text-md border-2 transition duration-200 border-base-color dark:border-primary text-base-color dark:text-light hover:bg-secondary dark:hover:bg-primary hover:text-white hover:border-secondary dark:hover:border-primary font-bold py-3 md:py-2 px-6 md:px-4">
               {/* NOTE: アクセシビリティの都合上、「続きを読む」は不適切判定なのでsr-onlyを付与 */}
               <span className="sr-only">{data.title}の</span>
-              続きを読む
+              {t('readMore')}
             </Link>
           </div>
         </div>

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -2,7 +2,7 @@ import dynamic from "next/dynamic";
 import { Suspense } from "react";
 
 import ArticleCard from "@/components/ArticleList/ArticleCard";
-import { getBlogList } from "@/lib/microcms";
+import { getBlogListByLocale } from "@/lib/microcms";
 import { PER_PAGE } from "@/static/blogs";
 import type { BlogTypeKeyLIteralType } from "@/types";
 import type { MicroCMSQueries } from "microcms-js-sdk";
@@ -16,10 +16,11 @@ type ArticleListProps = {
   blogType: BlogTypeKeyLIteralType
   page: string
   basePath?: string
+  locale: string
 }
 
-const ArticleList = async ({ query, blogType, page, basePath }: ArticleListProps) => {
-  const data = await getBlogList({ ...query, orders: "-publishedAt" }, { next: { revalidate: 86400 } });
+const ArticleList = async ({ query, blogType, page, basePath, locale }: ArticleListProps) => {
+  const data = await getBlogListByLocale(locale, { ...query, orders: "-publishedAt" }, { next: { revalidate: 86400 } });
   const contentCount = data.contents.length
   const emptyItem = PER_PAGE - contentCount
   return (

--- a/src/components/CategoryList/index.tsx
+++ b/src/components/CategoryList/index.tsx
@@ -1,14 +1,27 @@
+import { getTranslations } from 'next-intl/server';
 import CategoryItem from "@/components/CategoryList/CategoryItem";
-import { CATEGORY_ARRAY } from "@/static/blogs";
+import { CATEGORY_MAPED_ID } from "@/static/blogs";
 
-const CategoryList = async () => {
+type CategoryListProps = {
+  locale: string;
+}
+
+const CategoryList = async ({ locale }: CategoryListProps) => {
+  const t = await getTranslations({ locale, namespace: 'categories' });
+  const tBlog = await getTranslations({ locale, namespace: 'blog' });
+  
+  // カテゴリ配列を翻訳データで生成
+  const categoryArray = Object.entries(CATEGORY_MAPED_ID).map(([_, id]) => ({
+    id,
+    name: t(id)
+  }));
 
   return (
     <div className="relative" data-testid="pw-category-list">
-      <div className="text-xl mb-8 px-0.5 dark:text-gray-400">Category</div>
+      <div className="text-xl mb-8 px-0.5 dark:text-gray-400">{tBlog('categories')}</div>
       <nav className="md:overflow-y-scroll md:max-h-[348px]">
         <ul className="divide-y-0 md:divide-y divide-gray-300 dark:divide-gray-600 flex flex-wrap gap-4 md:gap-0 md:flex-col">
-          {CATEGORY_ARRAY.map(({ id, name }) => (
+          {categoryArray.map(({ id, name }) => (
             <CategoryItem key={id} id={id} categoryName={name} />
           ))}
         </ul>

--- a/src/components/ErrorPageFooter/index.tsx
+++ b/src/components/ErrorPageFooter/index.tsx
@@ -1,0 +1,20 @@
+interface ErrorPageFooterProps {
+  locale: string;
+}
+
+const ErrorPageFooter = ({ locale }: ErrorPageFooterProps) => {
+  const currentYear = new Date().getFullYear();
+  
+  return (
+    <footer className="bg-white dark:bg-black border-t border-gray-200 dark:border-gray-600 py-8">
+      <div className="container mx-auto px-2 md:px-0">
+        <div className="text-center text-gray-600 dark:text-gray-400">
+          <p>&copy; {currentYear} {locale === 'en' ? "Ryota's Web Engineer Blog" : 'りょうたのWebエンジニアブログ'}</p>
+          <p className="mt-2">All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default ErrorPageFooter;

--- a/src/components/ErrorPageHeader/index.tsx
+++ b/src/components/ErrorPageHeader/index.tsx
@@ -1,0 +1,38 @@
+import { Link } from 'next-view-transitions';
+import { SITE_TITLE } from "@/static/blogs";
+
+interface ErrorPageHeaderProps {
+  locale: string;
+}
+
+const ErrorPageHeader = ({ locale }: ErrorPageHeaderProps) => {
+  return (
+    <header className="bg-white dark:bg-black pt-4 shadow-md">
+      <div className="container mx-auto px-2 md:px-0">
+        <div className="flex justify-between items-center mb-4">
+          <div className="flex justify-between w-full">
+            <Link href={`/${locale}/blogs`} className="text-2xl font-bold text-gray-800 dark:text-gray-200 hover:text-base-color transition duration-200">
+              {SITE_TITLE}
+            </Link>
+          </div>
+        </div>
+        <nav className="py-4">
+          <ul className="flex space-x-6">
+            <li>
+              <Link href={`/${locale}/blogs`} className="text-gray-600 dark:text-gray-300 hover:text-base-color transition duration-200">
+                {locale === 'en' ? 'Blog' : 'ブログ'}
+              </Link>
+            </li>
+            <li>
+              <Link href={`/${locale}/about`} className="text-gray-600 dark:text-gray-300 hover:text-base-color transition duration-200">
+                {locale === 'en' ? 'About' : 'プロフィール'}
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default ErrorPageHeader;

--- a/src/components/Header/BlogTitle/index.tsx
+++ b/src/components/Header/BlogTitle/index.tsx
@@ -6,7 +6,7 @@ type PropsType = {
 }
 
 const BlogTitle = ({ title, locale }: PropsType) => {
-  const href = locale ? `/${locale}/blogs` : '/blogs';
+  const href = locale ? `/${locale}` : '/';
   
   return (
     <Link href={href}>

--- a/src/components/NotFoundContent/index.tsx
+++ b/src/components/NotFoundContent/index.tsx
@@ -1,17 +1,13 @@
-"use client"
+'use client';
 
-import ErrorPageFooter from "@/components/ErrorPageFooter";
-import ErrorPageHeader from "@/components/ErrorPageHeader";
-import { Link } from 'next-view-transitions';
+import { Link } from 'next-view-transitions'
 import Image from "next/image";
 import { usePathname } from 'next/navigation';
 
-interface ErrorPageProps {
-  error: Error & { digest?: string };
-  reset: () => void;
-}
+import ErrorPageFooter from "@/components/ErrorPageFooter";
+import ErrorPageHeader from "@/components/ErrorPageHeader";
 
-const Page = ({ error, reset }: ErrorPageProps) => {
+const NotFoundContent = () => {
   const pathname = usePathname();
   // パスからロケールを取得（デフォルトは日本語）
   const locale = pathname?.startsWith('/en') ? 'en' : 'ja';
@@ -19,11 +15,11 @@ const Page = ({ error, reset }: ErrorPageProps) => {
   // ロケールに応じた翻訳を手動で定義
   const messages = {
     ja: {
-      message: 'サーバー内部のエラーが発生しました。',
+      message: 'お探しのページが見つかりませんでした。',
       backToHome: 'トップページに戻る'
     },
     en: {
-      message: 'An internal server error occurred.',
+      message: 'The page you are looking for could not be found.',
       backToHome: 'Back to Home'
     }
   };
@@ -34,10 +30,10 @@ const Page = ({ error, reset }: ErrorPageProps) => {
     <>
       <ErrorPageHeader locale={locale} />
       <main className="flex-grow flex flex-col md:flex-row container mx-auto gap-4 my-4 h-full px-2">
-        <div className="flex w-full flex-col items-center justify-center bg-white px-4 py-12 dark:bg-gray-900 border-2 border-gray-200 dark:border-gray-600">
+        <div className="flex-grow flex w-full flex-col items-center justify-center bg-white p-4 dark:bg-gray-900 border-2 border-gray-200 dark:border-gray-600">
           <div className="flex flex-col items-center justify-center space-y-4">
-          <Image src="/500.png" alt="Internal Server Error" width={300} height={300} sizes="100vw" style={{ width: '50%', height: 'auto' }} />
-            <h1 className="text-8xl font-bold text-gray-800 dark:text-gray-200">500</h1>
+          <Image src="/404.png" alt="No contents" width={300} height={300} sizes="100vw" style={{ width: '50%', height: 'auto' }} />
+            <h1 className="text-8xl font-bold text-gray-800 dark:text-gray-200">404</h1>
             <p className="text-lg font-medium text-gray-600 dark:text-gray-400">
               {t.message}
             </p>
@@ -51,4 +47,4 @@ const Page = ({ error, reset }: ErrorPageProps) => {
     </>
   )
 }
-export default Page
+export default NotFoundContent;

--- a/src/components/Pagination/EllipsisMenu/EllipsisMenuItem/index.tsx
+++ b/src/components/Pagination/EllipsisMenu/EllipsisMenuItem/index.tsx
@@ -14,11 +14,12 @@ const EllipsisMenuItem = ({ pageNumber, children }: EllipsisMenuItemProps) => {
   const pathname = usePathname()
 
   const generateHref = useCallback(() => {
-    // カテゴリページかどうかを確認
-    const categoryPathMatch = pathname.match(/^\/blogs\/([^\/]+)$/)
-    const categoryId = categoryPathMatch ? categoryPathMatch[1] : null
+    // 国際化対応: カテゴリページかどうかを確認
+    const categoryPathMatch = pathname.match(/^\/([^\/]+)\/blogs\/([^\/]+)$/)
+    const locale = categoryPathMatch ? categoryPathMatch[1] : pathname.match(/^\/([^\/]+)/)?.[1] || 'ja'
+    const categoryId = categoryPathMatch ? categoryPathMatch[2] : null
     
-    let baseHref = categoryId ? `/blogs/${categoryId}` : `/blogs`
+    let baseHref = categoryId ? `/${locale}/blogs/${categoryId}` : `/${locale}/blogs`
     const keyword = searchParams?.get('keyword') ?? ""
 
     if (keyword) {

--- a/src/components/Pagination/PaginationItem/index.tsx
+++ b/src/components/Pagination/PaginationItem/index.tsx
@@ -27,13 +27,14 @@ const PaginationItem = ({ pageNumber, children, currentPage, basePath }: Paginat
       return `${basePath}/page/${pageNumber}`
     }
 
-    // カテゴリページかどうかを確認
-    const categoryPathMatch = pathname?.match(/^\/blogs\/([^\/]+)$/)
-    const categoryId = categoryPathMatch ? categoryPathMatch[1] : null
+    // 国際化対応: カテゴリページかどうかを確認
+    const categoryPathMatch = pathname?.match(/^\/([^\/]+)\/blogs\/([^\/]+)$/)
+    const locale = categoryPathMatch ? categoryPathMatch[1] : pathname?.match(/^\/([^\/]+)/)?.[1] || 'ja'
+    const categoryId = categoryPathMatch ? categoryPathMatch[2] : null
     
     const keyword = searchParams?.get('keyword') ?? ""
     
-    let baseHref = categoryId ? `/blogs/${categoryId}` : `/blogs`
+    let baseHref = categoryId ? `/${locale}/blogs/${categoryId}` : `/${locale}/blogs`
 
     if (keyword) {
       const currentPath = `${baseHref}?keyword=${keyword}`

--- a/src/components/RelatedContentList/RelatedContentItem/index.tsx
+++ b/src/components/RelatedContentList/RelatedContentItem/index.tsx
@@ -4,7 +4,7 @@ import Chip from "@/components/UiParts/Chip";
 import { CATEGORY_MAPED_NAME } from "@/static/blogs";
 import { CategoriesContentType } from "@/types/microcms";
 import { Link } from "next-view-transitions";
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 type RelatedContentItemProps = {
   id: string;
@@ -16,6 +16,7 @@ type RelatedContentItemProps = {
 
 const RelatedContentItem = ({ id, publishedAt, updatedAt, title, category }: RelatedContentItemProps) => {
   const locale = useLocale();
+  const t = useTranslations('categories');
   const displayTime = publishedAt || updatedAt;
   const primaryCategoryId = category.length > 0 ? category[0].id : "programming";
   
@@ -29,7 +30,7 @@ const RelatedContentItem = ({ id, publishedAt, updatedAt, title, category }: Rel
         <ul className="flex flex-wrap items-center gap-1 w-full md:w-auto justify-end">
           {category.map(({ id }) => (
             <li key={id}>
-              <Chip label={CATEGORY_MAPED_NAME[id]} classes="bg-gray-300 dark:bg-gray-600 dark:text-gray-300 px-2 py-0.5 text-xs text-txt-base" />
+              <Chip label={t(id)} classes="bg-gray-300 dark:bg-gray-600 dark:text-gray-300 px-2 py-0.5 text-xs text-txt-base" />
             </li>
           ))}
         </ul>

--- a/src/components/RelatedContentList/index.tsx
+++ b/src/components/RelatedContentList/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+import { useTranslations } from 'next-intl';
 import RelatedContentItem from "@/components/RelatedContentList/RelatedContentItem";
 import { BlogsContentType } from "@/types/microcms";
 
@@ -6,10 +8,11 @@ type RelatedContentProps = {
 }
 
 const RelatedContentList = ({ data }: RelatedContentProps) => {
+  const t = useTranslations('blog');
 
   return (
     <>
-      <div className="text-2xl dark:text-gray-300 font-bold mb-4">関連記事</div>
+      <div className="text-2xl dark:text-gray-300 font-bold mb-4">{t('relatedPosts')}</div>
       <ul className="divide-y">
         {data.map(({ id, publishedAt, updatedAt, title, category }) => (
           <RelatedContentItem key={id} id={id} publishedAt={publishedAt} updatedAt={updatedAt} title={title} category={category} />

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useContext, useRef, type FormEvent } from "react"
 import { useRouter, usePathname } from "next/navigation"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { GlobalContext } from "@/providers"
 import { cltw } from "@/util"
 import { escapeHtml } from "@/lib"
@@ -11,6 +11,7 @@ const SearchBar = () => {
   const router = useRouter()
   const pathname = usePathname()
   const locale = useLocale()
+  const t = useTranslations('blog')
   const formRef = useRef<HTMLFormElement>(null)
 
   // stateがundefinedの場合のフォールバック
@@ -51,14 +52,14 @@ const SearchBar = () => {
         name="keyword"
         type="text"
         className={cltw("w-full px-4 py-2 border-2 transition-colors duration-500 dark:border-gray-600 dark:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-base-color dark:focus:ring-primary focus:border-transparent", blogType === "zenn" ? "bg-gray-300 cursor-not-allowed" : "bg-white")}
-        placeholder={blogType === "zenn" ? "※ Zennの記事は検索非対応" : "Search..."}
+        placeholder={blogType === "zenn" ? t('zennSearchNotSupported') : t('searchPlaceholder')}
         disabled={blogType === "zenn"}
         aria-disabled={blogType === "zenn"}
         data-testid="pw-search-bar-input"
       />
       <button
         type="submit"
-        aria-label="検索"
+        aria-label={t('search')}
         disabled={blogType === "zenn"}
         aria-disabled={blogType === "zenn"}
         className={cltw("text-white px-2 ml-2 block my-0.5 transition-all duration-500 rounded-sm ", blogType === "zenn" ? "bg-gray-500 cursor-not-allowed" : "bg-base-color hover:opacity-80 active:bg-secondary dark:bg-primary")}

--- a/src/components/SearchStateCard/index.tsx
+++ b/src/components/SearchStateCard/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Link } from 'next-view-transitions';
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import Chip from "@/components/UiParts/Chip";
 import type { MappedKeyLiteralType } from "@/types/microcms";
 
@@ -18,6 +18,7 @@ type SearchStateCardProps = {
 
 const SearchStateCard = ({ keyword, category }: SearchStateCardProps) => {
   const locale = useLocale();
+  const t = useTranslations('blog');
   
   return (
     <div className="bg-white dark:bg-black px-3.5 flex flex-grow flex-col lg:flex-row items-center gap-2 lg:gap-10 border-2 border-gray-200 dark:border-gray-600">
@@ -26,7 +27,7 @@ const SearchStateCard = ({ keyword, category }: SearchStateCardProps) => {
           <circle cx="10" cy="10" r="8"></circle>
           <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
         </svg>
-        <p className="text-sm lg:text-lg text-gray-500 dark:text-gray-300">検索条件 </p>
+        <p className="text-sm lg:text-lg text-gray-500 dark:text-gray-300">{t('searchConditions')} </p>
       </div>
       <div className="flex flex-col lg:flex-row flex-grow justify-between items-center gap w-full lg:w-auto">
         <ul className="flex gap-4 items-center">
@@ -42,7 +43,7 @@ const SearchStateCard = ({ keyword, category }: SearchStateCardProps) => {
           )}
         </ul>
         <div className="w-full lg:w-auto text-right" data-testid="pw-reset-search-state">
-          <Link href={`/${locale}/blogs`} className="text-gray-400 text-xs cursor-pointer transition-colors hover:text-gray-700 dark:hover:text-gray-300">検索条件をリセット</Link>
+          <Link href={`/${locale}/blogs`} className="text-gray-400 text-xs cursor-pointer transition-colors hover:text-gray-700 dark:hover:text-gray-300">{t('resetSearchConditions')}</Link>
         </div>
       </div>
     </div>

--- a/src/components/SideNav/index.tsx
+++ b/src/components/SideNav/index.tsx
@@ -1,13 +1,17 @@
 import CategoryList from "@/components/CategoryList";
 import SearchBar from "@/components/SearchBar";
 
-const SideNav = () => {
+type SideNavProps = {
+  locale: string;
+}
+
+const SideNav = ({ locale }: SideNavProps) => {
   return (
     <aside className="w-full md:w-[300px] flex flex-col gap-8 px-2 md:px-0">
       <div className="mt-7">
         <SearchBar />
       </div>
-      <CategoryList />
+      <CategoryList locale={locale} />
     </aside>
   )
 }

--- a/src/components/UiParts/InfoYearsCard/index.tsx
+++ b/src/components/UiParts/InfoYearsCard/index.tsx
@@ -1,12 +1,19 @@
+'use client';
+import { useTranslations } from 'next-intl';
+
 type InfoYearsCardProps = {
   diffYear: number
 }
 
 const InfoYearsCard = ({ diffYear }: InfoYearsCardProps) => {
+  const t = useTranslations('blog');
   return (
     <div className="bg-yellow-200 p-2 md:p-4 inline-block">
       <p className="text-orange-400 font-bold text-sm md:text-md">
-        こちらは <span className="text-xl md:text-2xl underline underline-offset-4">{diffYear}</span> 年前に公開された記事です
+        {t.rich('oldArticleNotice', {
+          years: (chunks) => <span className="text-xl md:text-2xl underline underline-offset-4">{chunks}</span>,
+          diffYear: diffYear
+        })}
       </p>
     </div>
   )

--- a/src/components/UiParts/IssueButton/index.tsx
+++ b/src/components/UiParts/IssueButton/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+import { useTranslations } from 'next-intl';
 import ExternalLink from "@/components/UiParts/ExternalLink";
 import Image from "next/image";
 
@@ -6,7 +8,8 @@ type IssueButtonProps = {
 }
 
 const IssueButton = ({ currentPath }: IssueButtonProps) => {
-  const bodyText = `対象ページ: ${currentPath}\n\n■修正箇所\n\n■修正の理由\n\n■改善提案\n\n■その他\n`;
+  const t = useTranslations('blog');
+  const bodyText = t('issueTemplate', { url: currentPath });
   const encodedBodyText = encodeURIComponent(bodyText);
   const href = `https://github.com/ryota-09/ryota-blog/issues/new?body=${encodedBodyText}`;
   return (
@@ -15,7 +18,7 @@ const IssueButton = ({ currentPath }: IssueButtonProps) => {
         <Image src="/icons/github.webp" alt="GitHub" width={24} height={24} />
       </figure>
       <div className=" text-txt-base dark:text-gray-400 text-center flex-grow">
-        修正をリクエストする
+        {t('requestCorrection')}
       </div>
     </ExternalLink>
   )

--- a/src/components/UiParts/NoContentsPage/BackToTopLink.tsx
+++ b/src/components/UiParts/NoContentsPage/BackToTopLink.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import { Link } from "next-view-transitions";
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 const BackToTopLink = () => {
   const locale = useLocale();
+  const t = useTranslations('error');
   
   return (
     <Link href={`/${locale}/blogs`} className="text-base-color border-2 border-base-color w-fit px-4 py-2 hover:bg-base-color hover:text-white hover:border-base-color transition duration-200">
-      トップページに戻る
+      {t('noContent.backToHome')}
     </Link>
   );
 };

--- a/src/components/UiParts/NoContentsPage/index.tsx
+++ b/src/components/UiParts/NoContentsPage/index.tsx
@@ -1,12 +1,17 @@
-import ImageWithBlur from "@/components/UiParts/ImageWithBlur";
+'use client';
+
+import Image from "next/image";
 import BackToTopLink from "./BackToTopLink";
+import { useTranslations } from 'next-intl';
 
 const NoContents = () => {
+  const t = useTranslations('error');
+  
   return (
     <div className="h-full bg-white dark:bg-black border-2 border-gray-200 dark:dark:border-gray-600 py-4 px-4 flex flex-col md:flex-row justify-center items-center" data-testid="pw-no-content-page">
-      <ImageWithBlur src="/no_contents.png" alt="No contents" width={300} height={300} sizes="100vw" style={{ width: '60%', height: 'auto' }} className="max-h-[500px]" />
+      <Image src="/no_contents.png" alt="No contents" width={300} height={300} sizes="100vw" style={{ width: '60%', height: 'auto' }} className="max-h-[500px]" />
       <div className="flex flex-col gap-8">
-        <p className="dark:text-gray-400 text-center md:text-left">表示できるコンテンツが<br className="inline md:hidden" />ありません。</p>
+        <p className="dark:text-gray-400 text-center md:text-left">{t('noContent.message')}</p>
         <div className="flex justify-center md:justify-start">
           <BackToTopLink />
         </div>

--- a/src/components/ZennArticleList/index.tsx
+++ b/src/components/ZennArticleList/index.tsx
@@ -1,8 +1,14 @@
+import { getTranslations } from 'next-intl/server'
 import Accordion from "@/components/UiParts/Accordion"
 import ZennArticleItem from "@/components/ZennArticleList/ZennArticleItem"
 import data from "@/static/rss/data.json"
 
-const ZennArticleList = () => {
+type ZennArticleListProps = {
+  locale: string;
+}
+
+const ZennArticleList = async ({ locale }: ZennArticleListProps) => {
+  const t = await getTranslations({ locale, namespace: 'blog' });
   return (
     // NOTE: フッターの位置を調整するため、mb-[101px]を追加
     <nav className="opacity-0 animate-fadeIn mb-[101px]">
@@ -11,7 +17,7 @@ const ZennArticleList = () => {
           <ZennArticleItem key={index} link={link} title={title} date={isoDate} />
         ))}
       </ul>
-      <Accordion title="もっと見る" classes="w-full p-4 cursor-pointer text-center transition hover:bg-blue-100 hover:opacity-70 duration-300 group-open:bg-transparent group-open:opacity-0 group-open:cursor-auto group-open:p-0">
+      <Accordion title={t('showMore')} classes="w-full p-4 cursor-pointer text-center transition hover:bg-blue-100 hover:opacity-70 duration-300 group-open:bg-transparent group-open:opacity-0 group-open:cursor-auto group-open:p-0">
         <ul className="group-open:grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8 hidden">
           {data.slice(6).map(({ link, title, isoDate }, index) => (
             <ZennArticleItem key={index} link={link} title={title} date={isoDate} />

--- a/src/lib/i18n-utils.ts
+++ b/src/lib/i18n-utils.ts
@@ -2,6 +2,8 @@
  * i18n関連のユーティリティ関数
  */
 
+import type { CategoriesContentType } from "@/types/microcms";
+
 /**
  * 現在のパスから別のlocaleのパスを生成
  */
@@ -74,4 +76,16 @@ export function getCategoryPaginationPath(locale: string, categoryId: string, pa
     return getCategoryPath(locale, categoryId);
   }
   return `/${locale}/blogs/${categoryId}/page/${page}`;
+}
+
+/**
+ * ロケールに応じたカテゴリ名を取得
+ */
+export function getLocalizedCategoryName(category: CategoriesContentType, locale: string): string {
+  // 英語ロケールでname_enが存在する場合はそれを使用
+  if (locale === 'en' && category.name_en) {
+    return category.name_en;
+  }
+  // それ以外は日本語名を使用
+  return category.name;
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,5 @@
 import type { MicroCMSQueries } from "microcms-js-sdk";
+import { getTranslations } from 'next-intl/server';
 
 import type { BreadcrumbItemType, TOCAssetsType } from "@/types";
 import { CATEGORY_MAPED_ID, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY, PER_PAGE, CATEGORY_MAPED_NAME } from "@/static/blogs";
@@ -65,15 +66,18 @@ export const getPrimaryCategoryId = (blog: Pick<BlogsContentType, "category">): 
   return CATEGORY_MAPED_ID[categoryName] || "programming";
 }
 
-export const generateBreadcrumbAssets = (blog: BlogsContentType, locale?: string): BreadcrumbItemType[] => {
+export const generateBreadcrumbAssets = async (blog: BlogsContentType, locale: string = 'ja'): Promise<BreadcrumbItemType[]> => {
   const categoryId = getPrimaryCategoryId(blog);
-  const categoryName = CATEGORY_MAPED_NAME[categoryId];
-  const localePrefix = locale ? `/${locale}` : '';
+  const t = await getTranslations({ locale, namespace: 'navigation' });
+  const tCategories = await getTranslations({ locale, namespace: 'categories' });
+  
+  const categoryName = tCategories(categoryId);
+  const localePrefix = `/${locale}`;
   
   const results = [
     {
-      label: "Home",
-      href: `${localePrefix}/blogs`
+      label: t('home'),
+      href: localePrefix
     },
     {
       label: categoryName,

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -58,26 +58,6 @@ export const getAllBlogList = async (querys?: MicroCMSQueries, customRequestInit
   return data;
 }
 
-export const getBlogById = (contentId: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) =>
-  MicroCMSApiGetSingleObjectHandler<BlogsContentType>(
-    "blogs",
-    querys,
-    customRequestInit,
-    contentId,
-  );
-
-export const getAllBlogIds = async (alternatedField?: string) => {
-  const data = await client.getAllContentIds({ endpoint: "blogs", alternateField: alternatedField });
-  return data;
-}
-
-export const getBlogByKeyword = (keyword: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) => {
-  return MicroCMSApiGetListHandler<BlogsContentType>("blogs", {
-    q: keyword,
-    ...querys,
-    ...customRequestInit,
-  });
-}
 
 export const getAllCategoryList = async (querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) => {
   const data = await client.getAllContents<CategoriesContentType>({ "endpoint": "categories", ...querys, ...customRequestInit });
@@ -92,13 +72,78 @@ export const getCategoryById = (contentId: string, querys?: MicroCMSQueries, cus
     contentId,
   );
 
-export const getPopularBlogsByCategory = async (
+
+// English blog functions
+export const getBlogListEn = (querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) =>
+  MicroCMSApiGetListHandler<BlogsContentType>("blogs_en", querys, customRequestInit);
+
+export const getAllBlogListEn = async (querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) => {
+  const data = client.getAllContents<BlogsContentType>({ "endpoint": "blogs_en", ...querys, ...customRequestInit });
+  return data;
+}
+
+export const getBlogByIdEn = (contentId: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) =>
+  MicroCMSApiGetSingleObjectHandler<BlogsContentType>(
+    "blogs_en",
+    querys,
+    customRequestInit,
+    contentId,
+  );
+
+export const getAllBlogIdsEn = async (alternatedField?: string) => {
+  const data = await client.getAllContentIds({ endpoint: "blogs_en", alternateField: alternatedField });
+  return data;
+}
+
+export const getBlogByKeywordEn = (keyword: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) => {
+  return MicroCMSApiGetListHandler<BlogsContentType>("blogs_en", {
+    q: keyword,
+    ...querys,
+    ...customRequestInit,
+  });
+}
+
+// Locale-aware wrapper functions
+export const getBlogListByLocale = (locale: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) => {
+  return locale === 'en' ? getBlogListEn(querys, customRequestInit) : getBlogList(querys, customRequestInit);
+}
+
+export const getAllBlogListByLocale = async (locale: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) => {
+  return locale === 'en' ? getAllBlogListEn(querys, customRequestInit) : getAllBlogList(querys, customRequestInit);
+}
+
+export const getBlogByIdByLocale = (locale: string, contentId: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) => {
+  return locale === 'en' 
+    ? getBlogByIdEn(contentId, querys, customRequestInit) 
+    : MicroCMSApiGetSingleObjectHandler<BlogsContentType>("blogs", querys, customRequestInit, contentId);
+}
+
+export const getAllBlogIdsByLocale = async (locale: string, alternatedField?: string) => {
+  if (locale === 'en') {
+    return getAllBlogIdsEn(alternatedField);
+  } else {
+    return await client.getAllContentIds({ endpoint: "blogs", alternateField: alternatedField });
+  }
+}
+
+export const getBlogByKeywordByLocale = (locale: string, keyword: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) => {
+  const endpoint = locale === 'en' ? 'blogs_en' : 'blogs';
+  return MicroCMSApiGetListHandler<BlogsContentType>(endpoint as EndPointLiteralType, {
+    q: keyword,
+    ...querys,
+    ...customRequestInit,
+  });
+}
+
+export const getPopularBlogsByCategoryByLocale = async (
+  locale: string,
   categoryName: string,
   limit: number = 3,
   customRequestInit?: CustomRequestInit
 ) => {
+  const endpoint = locale === 'en' ? 'blogs_en' : 'blogs';
   const data = await client.get<BaseMicroCMSApiListDataType<BlogsContentType>>({
-    endpoint: "blogs",
+    endpoint: endpoint as EndPointLiteralType,
     queries: {
       fields: "id,title,publishedAt,updatedAt,category,pageViews,thumbnail,description",
       filters: `category[contains]${categoryName}`,
@@ -116,11 +161,13 @@ export const getPopularBlogsByCategory = async (
   return data.contents;
 };
 
-export const getPrevAndNextBlog = async (data: BlogsContentType) => {
+export const getPrevAndNextBlogByLocale = async (locale: string, data: BlogsContentType) => {
   const publishedAt = data.publishedAt;
+  const endpoint = locale === 'en' ? 'blogs_en' : 'blogs';
+  
   const [prev, next] = await Promise.all([
     client.get<BaseMicroCMSApiListDataType<BlogsContentType>>({
-      endpoint: "blogs",
+      endpoint: endpoint as EndPointLiteralType,
       queries: {
         fields: "id,title,publishedAt,updatedAt,category",
         filters: `publishedAt[less_than]${publishedAt}`,
@@ -135,7 +182,7 @@ export const getPrevAndNextBlog = async (data: BlogsContentType) => {
       }
     }),
     client.get<BaseMicroCMSApiListDataType<BlogsContentType>>({
-      endpoint: "blogs",
+      endpoint: endpoint as EndPointLiteralType,
       queries: {
         fields: "id,title,publishedAt,updatedAt,category",
         filters: `publishedAt[greater_than]${publishedAt}`,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import createMiddleware from 'next-intl/middleware';
 import { routing } from './i18n/routing';
-import { getBlogById } from './lib/microcms'
+import { getBlogByIdByLocale } from './lib/microcms'
 import { getPrimaryCategoryId } from './lib/index'
 
 // Create the intl middleware
@@ -43,7 +43,7 @@ export async function middleware(request: NextRequest) {
       console.log('Attempting to redirect blog:', blogId);
       
       try {
-        const blog = await getBlogById(blogId, { fields: 'category' })
+        const blog = await getBlogByIdByLocale(routing.defaultLocale, blogId, { fields: 'category' })
         const categoryId = getPrimaryCategoryId(blog)
         
         // 新しいURL構造にデフォルトlocaleでリダイレクト
@@ -80,7 +80,7 @@ export async function middleware(request: NextRequest) {
     
     console.log('Processing locale blog redirect:', locale, blogId);
     try {
-      const blog = await getBlogById(blogId, { fields: 'category' })
+      const blog = await getBlogByIdByLocale(locale, blogId, { fields: 'category' })
       const categoryId = getPrimaryCategoryId(blog)
       
       // localeありの新しいURL構造にリダイレクト

--- a/src/static/blogs.ts
+++ b/src/static/blogs.ts
@@ -1,5 +1,7 @@
 export const AUTHOR_NAME = 'りょた';
+export const AUTHOR_NAME_EN = 'Ryota';
 export const AUTHOR_DESCRIPTION = 'りょたといいます！ 都内でエンジニアやってます！ Software Developer | DevCan#2 hostedBy Classmethod | React.js | Next.js | AWS SAA / DVA / SOA';
+export const AUTHOR_DESCRIPTION_EN = 'Hi, I\'m Ryota! I\'m a software engineer working in Tokyo! Software Developer | DevCan#2 hostedBy Classmethod | React.js | Next.js | AWS SAA / DVA / SOA';
 export const SITE_TITLE = 'Ryota-Blog';
 export const SITE_DOMAIN = 'ryotablog.jp';
 export const AUTHOR_E_MAIL = "ryotadevelop@webclouddev.com";

--- a/src/static/header.ts
+++ b/src/static/header.ts
@@ -4,7 +4,7 @@ import type { HeaderNavItem } from "@/types/header";
 export const getHeaderNavItems = (locale: string): HeaderNavItem[] => [
   {
     name: 'Home',
-    href: `/${locale}/blogs`,
+    href: `/${locale}`,
   },
   {
     name: 'About',
@@ -60,7 +60,7 @@ export const getSocialMediaNavItems = (locale: string): HeaderNavItem[] => [
 export const HEADER_NAV_ITEMS: HeaderNavItem[] = [
   {
     name: 'Home',
-    href: '/blogs',
+    href: '/',
   },
   {
     name: 'About',

--- a/src/types/microcms.ts
+++ b/src/types/microcms.ts
@@ -8,7 +8,7 @@ import type {
   CustomRequestInit,
 } from "microcms-js-sdk";
 
-const ENDPOINT_LIST = ["blogs", "categories"] as const;
+const ENDPOINT_LIST = ["blogs", "blogs_en", "categories"] as const;
 
 const CUSTOM_FIELD = {
   richEditor: "richEditor",
@@ -73,6 +73,7 @@ type APIContentType<T> = {
 
 export type CategoriesContentType = APIContentType<{
   name: MicroCMSFields["text"];
+  name_en?: MicroCMSFields["text"];
 }>
 
 export type BlogsContentType = APIContentType<{


### PR DESCRIPTION
microCMS英語エンドポイント(/blogs_en)対応とWebサイト全体の多言語化を実装

## 主な変更

### API・データ層
- microCMS英語エンドポイント(/blogs_en)対応
- カテゴリのname_enフィールド対応
- ロケール対応API関数の実装
- 旧API関数の削除とリファクタリング

### ルーティング・ナビゲーション
- /en/blogs および /en/blogs/[category] ルート実装
- パンくずリスト、ページネーション、検索の多言語対応
- 言語切り替え時の適切なリダイレクト処理

### UI コンポーネント国際化
- ヘッダー、フッター、サイドバーの翻訳対応
- 記事詳細ページ全要素(目次、関連記事、シェアボタン等)
- 検索機能、フィルター、エラーページ
- RSS、llms.txt等のAPIエンドポイント

### エラーハンドリング
- 404、500エラーページの多言語対応
- next-intlコンテキスト外でのエラー処理
- エラーページ専用Header/Footerコンポーネント

### メタデータ・SEO
- ロケール別メタデータ生成
- 多言語RSS フィード
- OpenGraph画像の言語対応

🤖 Generated with [Claude Code](https://claude.ai/code)