### PR TITLE
Add resource hints for third-party domains

### DIFF
--- a/src/components/Head/PreloadResources/index.tsx
+++ b/src/components/Head/PreloadResources/index.tsx
@@ -1,11 +1,23 @@
 'use client'
 import ReactDOM from 'react-dom'
+import { microCMSServiceDomain } from '@/config'
 
 const IMAGE_DOMAIN = 'https://images.microcms-assets.io'
 const PROJECT_ID = '4626924a681346e9a0fcabe5478eb9fa'
+const GTM_DOMAIN = 'https://www.googletagmanager.com'
+const GA_DOMAIN = 'https://www.google-analytics.com'
+const FONTS_API = 'https://fonts.googleapis.com'
+const FONTS_GSTATIC = 'https://fonts.gstatic.com'
 
 const PreloadResources = () => {
+  ReactDOM.preconnect(GTM_DOMAIN)
+  ReactDOM.preconnect(GA_DOMAIN)
+  ReactDOM.preconnect(FONTS_API)
+  ReactDOM.preconnect(FONTS_GSTATIC, { crossOrigin: "anonymous" })
+  ReactDOM.preconnect(`https://${microCMSServiceDomain}.microcms.io`)
+  ReactDOM.preconnect(IMAGE_DOMAIN, { crossOrigin: "anonymous" })
   ReactDOM.preconnect(`${IMAGE_DOMAIN}/assets/${PROJECT_ID}`, { crossOrigin: "anonymous" })
+  ReactDOM.prefetchDNS(GTM_DOMAIN)
   ReactDOM.prefetchDNS(IMAGE_DOMAIN)
   return null
 }


### PR DESCRIPTION
## Summary
- add new preconnect and dns-prefetch hints for Google and microCMS resources

## Testing
- `npm run lint`
- `npm run test` *(fails: context errors)*
- `npm run build` *(fails: vitest type errors)*
- `npx tsc --noEmit` *(fails: vite plugin type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6851570512d883248c0d602690d3525a