### PR TITLE
リッチエディタの言語未設定時のエラーを修正

### DIFF
--- a/src/components/ArticleBody/RichEditor/ReplaceUiParts.lib.tsx
+++ b/src/components/ArticleBody/RichEditor/ReplaceUiParts.lib.tsx
@@ -125,7 +125,8 @@ export const customReplaceOptions: HTMLReactParserOptions = {
             if (domNode.parent) {
               filename = "attribs" in domNode.parent ? domNode.parent.attribs['data-filename'] : null;
             }
-            const lang = domNode.children[0].attribs.class.replace('language-', '');
+            const langAttr = 'attribs' in domNode.children[0] ? domNode.children[0].attribs.class : undefined;
+            const lang = langAttr ? langAttr.replace('language-', '') : '';
             return <MultiCodeBlock filename={filename} lang={lang}>{"data" in domNode.children[0].children[0] ? domNode.children[0].children[0].data : ""}</MultiCodeBlock>;
           }
           return <pre>{domToReact(domNode.children as DOMNode[], customReplaceOptions)}</pre>


### PR DESCRIPTION
## 概要
- `ReplaceUiParts.lib.tsx` の `pre` タグ処理で `class` が存在しない場合にエラーになる問題を修正

## テスト
- `npm test` を実行しましたが、依存関係の問題で `@rollup/rollup-linux-x64-gnu` が見つからず失敗しました

------
https://chatgpt.com/codex/tasks/task_e_6853af52bea48324a8e9658ec7c2ea09