### PR TITLE
Nocontentsコンポーネントの高さをSkeleton UIに合わせる

### DIFF
--- a/src/components/UiParts/NoContentsPage/index.tsx
+++ b/src/components/UiParts/NoContentsPage/index.tsx
@@ -1,22 +1,35 @@
-'use client';
+"use client";
 
 import Image from "next/image";
 import BackToTopLink from "./BackToTopLink";
-import { useTranslations } from 'next-intl';
+import { useTranslations } from "next-intl";
 
 const NoContents = () => {
-  const t = useTranslations('error');
-  
+  const t = useTranslations("error");
+
   return (
-    <div className="h-full bg-white dark:bg-black border-2 border-gray-200 dark:dark:border-gray-600 py-4 px-4 flex flex-col md:flex-row justify-center items-center" data-testid="pw-no-content-page">
-      <Image src="/no_contents.png" alt="No contents" width={300} height={300} sizes="100vw" style={{ width: '60%', height: 'auto' }} className="max-h-[500px]" />
+    <div
+      className="flex h-full min-h-[2208px] flex-col items-center justify-center border-2 border-gray-200 bg-white px-4 py-4 dark:dark:border-gray-600 dark:bg-black md:min-h-[596px] md:flex-row"
+      data-testid="pw-no-content-page"
+    >
+      <Image
+        src="/no_contents.png"
+        alt="No contents"
+        width={300}
+        height={300}
+        sizes="100vw"
+        style={{ width: "60%", height: "auto" }}
+        className="max-h-[500px]"
+      />
       <div className="flex flex-col gap-8">
-        <p className="dark:text-gray-400 text-center md:text-left">{t('noContent.message')}</p>
+        <p className="text-center dark:text-gray-400 md:text-left">
+          {t("noContent.message")}
+        </p>
         <div className="flex justify-center md:justify-start">
           <BackToTopLink />
         </div>
       </div>
     </div>
   );
-}
+};
 export default NoContents;


### PR DESCRIPTION
## Summary
- Nocontentsページの高さをSkeleton UIと同等に設定しCLSを改善

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6853c9b868648324b9d0c998a23e1a41