### PR TITLE
Open Graphのサイト名を固定化し画像を削除

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,12 +7,12 @@ import { routing } from '@/i18n/routing';
 import { GoogleTagManager, GoogleAnalytics } from "@next/third-parties/google";
 import { baseURL, gaId, gtmId } from "@/config";
 
-interface LocaleLayoutProps {
+type LocaleLayoutProps = {
   children: React.ReactNode;
   params: {
     locale: string;
   };
-}
+};
 
 export async function generateMetadata({ params: { locale } }: LocaleLayoutProps): Promise<Metadata> {
   const t = await getTranslations({ locale, namespace: 'metadata' });
@@ -24,6 +24,11 @@ export async function generateMetadata({ params: { locale } }: LocaleLayoutProps
     },
     description: t('siteDescription'),
     metadataBase: new URL(baseURL),
+    openGraph: {
+      url: baseURL,
+      siteName: 'Ryota-Blog',
+      type: 'website'
+    }
   };
 }
 


### PR DESCRIPTION
## 概要
- `generateMetadata` の `openGraph` で `siteName` を固定値 `Ryota-Blog` に設定
- 不要な `public/images/og-image.jpg` を削除
- `LocaleLayoutProps` を `interface` から `type` に変更

## 動作確認
- `npm run lint` を実行し警告のみで完了することを確認
- `npm test` は Rollup の依存関係エラーで失敗
- `npx tsc --noEmit` はテストコードの型定義不足でエラー
- `npm run build` は環境変数不足により失敗


------
https://chatgpt.com/codex/tasks/task_e_685403a4f8c4832486a697bdb47f0d49