### PR TITLE
ブログ詳細ページのカテゴリChipのURLを修正

### DIFF
--- a/src/components/ArticleBody/CategoryTag.tsx
+++ b/src/components/ArticleBody/CategoryTag.tsx
@@ -3,6 +3,7 @@
 import { Link } from 'next-view-transitions';
 import { useLocale, useTranslations } from 'next-intl';
 import Chip from '@/components/UiParts/Chip';
+import { CATEGORY_MAPED_ID } from '@/static/blogs';
 
 type CategoryTagProps = {
   name: string;
@@ -13,37 +14,13 @@ const CategoryTag = ({ name, index }: CategoryTagProps) => {
   const locale = useLocale();
   const t = useTranslations('categories');
   
-  // カテゴリ名から対応するIDを取得（逆引き）
-  const getCategoryId = (categoryName: string) => {
-    const categoryMap: { [key: string]: string } = {
-      'Python': 'python',
-      'TypeScript': 'typescript',
-      'CSS': 'css',
-      'Next.js': 'next_js',
-      'Release Notes': 'release_notes',
-      'AWS': 'aws',
-      'レビュー': 'review',
-      '雑記': 'zakki',
-      'React': 'react',
-      'OpenAI API': 'openai_api',
-      'ガジェット': 'gadget',
-      'TailwindCSS': 'tailwindcss',
-      'UI': 'ui_parts',
-      'プログラミング': 'programming',
-      'Career': 'career',
-      'LifeHack': 'life_hack',
-      '時事': 'news',
-      'Terraform': 'terraform'
-    };
-    return categoryMap[categoryName] || 'programming';
-  };
-  
-  const categoryId = getCategoryId(name);
+  // カテゴリ名から対応するIDを取得
+  const categoryId = CATEGORY_MAPED_ID[name as keyof typeof CATEGORY_MAPED_ID] || 'programming';
   const localizedName = t(categoryId);
   
   return (
     <li key={index} className="block cursor-pointer">
-      <Link href={`/${locale}/blogs?category=${name}`}>
+      <Link href={`/${locale}/blogs/${categoryId}`}> 
         <Chip label={`#${localizedName}`} classes="bg-gray-200 dark:bg-gray-600 dark:text-gray-300 px-3 py-2 text-sm text-txt-base hover:opacity-60" />
       </Link>
     </li>


### PR DESCRIPTION
## Summary
- カテゴリ名からIDを取得する処理を定数 `CATEGORY_MAPED_ID` に変更
- ブログ詳細ページのカテゴリChipのリンクを `/blogs/<categoryId>` 形式に変更

## Testing
- `npm run lint`
- `npm run test` *(失敗)*
- `npx tsc --noEmit` *(失敗)*
- `npm run build` *(失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68578de435c88324ae135ea5968c8c7c