### PR TITLE
fix: GitHub ActionsのOIDC認証に必要な権限を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' || github.event_name == 'repository_dispatch'
+    permissions:
+      id-token: write
+      contents: read
     
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
wait-for-apprunner-and-invalidate-cacheジョブにid-token権限を設定し、 AWS認証エラーを解決。

🤖 Generated with [Claude Code](https://claude.ai/code)