### PR TITLE
fix: RootLayoutのlocale取得方法を修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,13 +21,17 @@ export const metadata: Metadata = {
   }
 };
 
+type RootLayoutProps = {
+  children: React.ReactNode;
+  params?: { locale?: string };
+};
+
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
-  // 静的生成のためデフォルトlocaleを使用
-  const locale = routing.defaultLocale;
+  params,
+}: RootLayoutProps) {
+  // URLから動的にlocaleを取得、フォールバックはデフォルトlocale
+  const locale = params?.locale || routing.defaultLocale;
 
   return (
     <ViewTransitions>


### PR DESCRIPTION
- 固定値から動的取得に変更してNext.js国際化機能を復旧
- paramsからlocaleを取得、フォールバックでデフォルトlocaleを使用
- 詳細ページのエラー（内部JSON表示）問題を解決
- CloudFrontキャッシュ最適化は維持

🤖 Generated with [Claude Code](https://claude.ai/code)