### PR TITLE
fix: CloudFrontキャッシュとnext-intl国際化の競合問題を解決

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -2,6 +2,7 @@ import SocialMediaIcons from "@/components/Header/SocialMediaIcons";
 import Chip from "@/components/UiParts/Chip";
 import ImageWithBlur from "@/components/UiParts/ImageWithBlur";
 import { AUTHOR_DESCRIPTION, AUTHOR_DESCRIPTION_EN, AUTHOR_NAME, AUTHOR_NAME_EN } from "@/static/blogs";
+import { setRequestLocale } from 'next-intl/server';
 
 interface AboutPageProps {
   params: {
@@ -10,6 +11,8 @@ interface AboutPageProps {
 }
 
 const Page = ({ params: { locale } }: AboutPageProps) => {
+  setRequestLocale(locale);
+  
   const authorName = locale === 'en' ? AUTHOR_NAME_EN : AUTHOR_NAME;
   const authorDescription = locale === 'en' ? AUTHOR_DESCRIPTION_EN : AUTHOR_DESCRIPTION;
   

--- a/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { cookies, draftMode } from "next/headers";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from 'next-intl/server';
 
 import ArticleBody from "@/components/ArticleBody";
 import BreadcrumbList from "@/components/BreadcrumbList";
@@ -59,6 +60,8 @@ type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
+  setRequestLocale(params.locale);
+  
   const blogId = params.blogId;
   const categoryParam = params.category;
   const { isEnabled } = draftMode();

--- a/src/app/[locale]/blogs/[category]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getTranslations } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
@@ -98,6 +98,8 @@ type PageProps = {
 };
 
 const Page = ({ params, searchParams }: PageProps) => {
+  setRequestLocale(params.locale);
+  
   const categoryName = CATEGORY_MAPED_NAME[params.category];
   
   if (!categoryName) {

--- a/src/app/[locale]/blogs/page.tsx
+++ b/src/app/[locale]/blogs/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
@@ -105,6 +105,8 @@ export async function generateMetadata({
 }
 
 const Page = ({ params: { locale }, searchParams }: PageProps) => {
+  setRequestLocale(locale);
+  
   const category = searchParams[CATEGORY_QUERY];
   const keyword = searchParams[KEYWORD_QUERY];
   const blogType = searchParams[BLOG_TYPE_QUERY] || "blogs";

--- a/src/app/[locale]/blogs/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/page/[page]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getTranslations } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
@@ -56,6 +56,8 @@ export async function generateMetadata(
 }
 
 const Page = async ({ params }: { params: { locale: string; page: string } }) => {
+  setRequestLocale(params.locale);
+  
   const pageNum = parseInt(params.page);
   
   // ページ番号の検証

--- a/src/app/[locale]/blogs/zenn/page.tsx
+++ b/src/app/[locale]/blogs/zenn/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getTranslations } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import SideNav from "@/components/SideNav";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
@@ -22,6 +22,8 @@ export async function generateMetadata({ params: { locale } }: ZennPageProps): P
 }
 
 const ZennPage = ({ params }: ZennPageProps) => {
+  setRequestLocale(params.locale);
+  
   return (
     <>
       <div className="w-full lg:w-[calc(100%_-_300px)] flex flex-col justify-between px-2 md:px-0">

--- a/src/app/[locale]/embedded/page.tsx
+++ b/src/app/[locale]/embedded/page.tsx
@@ -1,8 +1,11 @@
 import metaFetcher from 'meta-fetcher';
 import { unstable_cache } from 'next/cache';
 import EmbeddedCard from '@/components/EmbeddedCard';
+import { setRequestLocale } from 'next-intl/server';
 
-const Page = async ({ searchParams }: { searchParams: { url: string } }) => {
+const Page = async ({ params, searchParams }: { params: { locale: string }, searchParams: { url: string } }) => {
+  setRequestLocale(params.locale);
+  
   const url = searchParams.url
   const metadata = await unstable_cache((url: string) => metaFetcher(url), [url], { revalidate: 24 * 60 * 60 })(url)
   return (

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations } from 'next-intl/server';
 import { routing } from '@/i18n/routing';
+import Script from 'next/script';
 
 import { GoogleTagManager, GoogleAnalytics } from "@next/third-parties/google";
 import { baseURL, gaId, gtmId } from "@/config";
@@ -43,10 +44,19 @@ export default async function LocaleLayout({
   const messages = await getMessages();
 
   return (
-    <NextIntlClientProvider messages={messages}>
-      {children}
-      <GoogleTagManager gtmId={gtmId} />
-      <GoogleAnalytics gaId={gaId} />
-    </NextIntlClientProvider>
+    <>
+      <Script 
+        id="set-html-lang"
+        strategy="beforeInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `document.documentElement.lang = '${locale}';`
+        }} 
+      />
+      <NextIntlClientProvider messages={messages} locale={locale}>
+        {children}
+        <GoogleTagManager gtmId={gtmId} />
+        <GoogleAnalytics gaId={gaId} />
+      </NextIntlClientProvider>
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,21 +21,14 @@ export const metadata: Metadata = {
   }
 };
 
-type RootLayoutProps = {
-  children: React.ReactNode;
-  params?: { locale?: string };
-};
-
 export default function RootLayout({
   children,
-  params,
-}: RootLayoutProps) {
-  // URLから動的にlocaleを取得、フォールバックはデフォルトlocale
-  const locale = params?.locale || routing.defaultLocale;
-
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
   return (
     <ViewTransitions>
-      <html lang={locale}>
+      <html>
         <PreloadResources />
         <ClientLayout>
           <body className={`${KosugiMaru.className} bg-[#eee] dark:bg-[#333] flex flex-col min-h-screen`}>


### PR DESCRIPTION
- RootLayoutから動的locale取得を削除し静的生成を維持
- LocaleLayoutにNextIntlClientProviderのlocale設定とHTML lang属性の動的設定を追加
- 全ページコンポーネントにsetRequestLocaleを追加してuseLocale()を有効化
- 静的生成(SSG)を維持しながらCloudFrontキャッシュとnext-intl機能を両立
- 103ページすべての事前生成を確認済み

参考記事のsetRequestLocale方式を採用し、propsベースより簡潔で保守性の高い実装を実現

🤖 Generated with [Claude Code](https://claude.ai/code)