### PR TITLE
fix: Props-basedアプローチでnext-intl国際化問題を解決

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -2,7 +2,6 @@ import SocialMediaIcons from "@/components/Header/SocialMediaIcons";
 import Chip from "@/components/UiParts/Chip";
 import ImageWithBlur from "@/components/UiParts/ImageWithBlur";
 import { AUTHOR_DESCRIPTION, AUTHOR_DESCRIPTION_EN, AUTHOR_NAME, AUTHOR_NAME_EN } from "@/static/blogs";
-import { setRequestLocale } from 'next-intl/server';
 
 interface AboutPageProps {
   params: {
@@ -11,8 +10,6 @@ interface AboutPageProps {
 }
 
 const Page = ({ params: { locale } }: AboutPageProps) => {
-  setRequestLocale(locale);
-  
   const authorName = locale === 'en' ? AUTHOR_NAME_EN : AUTHOR_NAME;
   const authorDescription = locale === 'en' ? AUTHOR_DESCRIPTION_EN : AUTHOR_DESCRIPTION;
   

--- a/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { cookies, draftMode } from "next/headers";
 import { notFound } from "next/navigation";
-import { setRequestLocale } from 'next-intl/server';
 
 import ArticleBody from "@/components/ArticleBody";
 import BreadcrumbList from "@/components/BreadcrumbList";
@@ -60,8 +59,6 @@ type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  setRequestLocale(params.locale);
-  
   const blogId = params.blogId;
   const categoryParam = params.category;
   const { isEnabled } = draftMode();

--- a/src/app/[locale]/blogs/[category]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { getTranslations } from 'next-intl/server';
 
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
@@ -98,8 +98,6 @@ type PageProps = {
 };
 
 const Page = ({ params, searchParams }: PageProps) => {
-  setRequestLocale(params.locale);
-  
   const categoryName = CATEGORY_MAPED_NAME[params.category];
   
   if (!categoryName) {
@@ -123,9 +121,9 @@ const Page = ({ params, searchParams }: PageProps) => {
         <div className="flex flex-col flex-grow gap-4">
           <div className="flex gap-4 flex-col lg:flex-row">
             <div className="flex justify-center items-center p-3 bg-white dark:bg-black border-2 border-gray-200 dark:border-gray-600">
-              <BlogTypeTabs blogType={blogType} />
+              <BlogTypeTabs blogType={blogType} locale={params.locale} />
             </div>
-            <SearchStateCard category={categoryName} keyword={keyword} />
+            <SearchStateCard category={categoryName} keyword={keyword} locale={params.locale} />
           </div>
           {blogType === "zenn"
             ?

--- a/src/app/[locale]/blogs/[category]/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page/[page]/page.tsx
@@ -131,10 +131,10 @@ const Page = async ({ params }: PageProps) => {
           <div className="flex gap-4 flex-col lg:flex-row">
             <div className="flex justify-center items-center p-3 bg-white dark:bg-black border-2 border-gray-200 dark:border-gray-600">
               <Suspense fallback={<div>Loading...</div>}>
-                <BlogTypeTabs blogType={blogType} />
+                <BlogTypeTabs blogType={blogType} locale={params.locale} />
               </Suspense>
             </div>
-            <SearchStateCard category={categoryName} keyword={""} />
+            <SearchStateCard category={categoryName} keyword={""} locale={params.locale} />
           </div>
           <Suspense fallback={<Skelton />}>
             <ArticleList 

--- a/src/app/[locale]/blogs/page.tsx
+++ b/src/app/[locale]/blogs/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import { getTranslations } from "next-intl/server";
 
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
@@ -105,8 +105,6 @@ export async function generateMetadata({
 }
 
 const Page = ({ params: { locale }, searchParams }: PageProps) => {
-  setRequestLocale(locale);
-  
   const category = searchParams[CATEGORY_QUERY];
   const keyword = searchParams[KEYWORD_QUERY];
   const blogType = searchParams[BLOG_TYPE_QUERY] || "blogs";
@@ -120,10 +118,10 @@ const Page = ({ params: { locale }, searchParams }: PageProps) => {
         <div className="flex flex-grow flex-col gap-4">
           <div className="flex flex-col gap-4 lg:flex-row">
             <div className="flex items-center justify-center border-2 border-gray-200 bg-white p-3 dark:border-gray-600 dark:bg-black">
-              <BlogTypeTabs blogType={blogType} />
+              <BlogTypeTabs blogType={blogType} locale={locale} />
             </div>
             {(category || keyword) && (
-              <SearchStateCard category={category} keyword={keyword} />
+              <SearchStateCard category={category} keyword={keyword} locale={locale} />
             )}
           </div>
           {blogType === "zenn" ? (

--- a/src/app/[locale]/blogs/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/page/[page]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { getTranslations } from 'next-intl/server';
 
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
@@ -56,8 +56,6 @@ export async function generateMetadata(
 }
 
 const Page = async ({ params }: { params: { locale: string; page: string } }) => {
-  setRequestLocale(params.locale);
-  
   const pageNum = parseInt(params.page);
   
   // ページ番号の検証
@@ -87,7 +85,7 @@ const Page = async ({ params }: { params: { locale: string; page: string } }) =>
           <div className="flex gap-4 flex-col lg:flex-row">
             <div className="flex justify-center items-center p-3 bg-white dark:bg-black border-2 border-gray-200 dark:border-gray-600">
               <Suspense fallback={<div>Loading...</div>}>
-                <BlogTypeTabs blogType={blogType} />
+                <BlogTypeTabs blogType={blogType} locale={params.locale} />
               </Suspense>
             </div>
           </div>

--- a/src/app/[locale]/blogs/zenn/page.tsx
+++ b/src/app/[locale]/blogs/zenn/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { getTranslations } from 'next-intl/server';
 
 import SideNav from "@/components/SideNav";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
@@ -22,15 +22,13 @@ export async function generateMetadata({ params: { locale } }: ZennPageProps): P
 }
 
 const ZennPage = ({ params }: ZennPageProps) => {
-  setRequestLocale(params.locale);
-  
   return (
     <>
       <div className="w-full lg:w-[calc(100%_-_300px)] flex flex-col justify-between px-2 md:px-0">
         <div className="flex flex-col flex-grow gap-4">
           <div className="flex gap-4 flex-col lg:flex-row">
             <div className="flex justify-center items-center p-3 bg-white dark:bg-black border-2 border-gray-200 dark:border-gray-600">
-              <BlogTypeTabs blogType="zenn" />
+              <BlogTypeTabs blogType="zenn" locale={params.locale} />
             </div>
           </div>
           <ZennArticleList locale={params.locale} />

--- a/src/app/[locale]/embedded/page.tsx
+++ b/src/app/[locale]/embedded/page.tsx
@@ -1,11 +1,8 @@
 import metaFetcher from 'meta-fetcher';
 import { unstable_cache } from 'next/cache';
 import EmbeddedCard from '@/components/EmbeddedCard';
-import { setRequestLocale } from 'next-intl/server';
 
-const Page = async ({ params, searchParams }: { params: { locale: string }, searchParams: { url: string } }) => {
-  setRequestLocale(params.locale);
-  
+const Page = async ({ searchParams }: { searchParams: { url: string } }) => {
   const url = searchParams.url
   const metadata = await unstable_cache((url: string) => metaFetcher(url), [url], { revalidate: 24 * 60 * 60 })(url)
   return (

--- a/src/components/ArticleList/ArticleCard/index.stories.tsx
+++ b/src/components/ArticleList/ArticleCard/index.stories.tsx
@@ -61,7 +61,8 @@ const data: BlogsContentType = {
 export const Default: Story = {
   args: {
     data,
-    index: 0
+    index: 0,
+    locale: 'ja'
   },
   decorators: [
     (Story) => (

--- a/src/components/ArticleList/ArticleCard/index.tsx
+++ b/src/components/ArticleList/ArticleCard/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Link } from 'next-view-transitions'
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 
 import { BlogsContentType } from "@/types/microcms"
 import NewLabel from "@/components/UiParts/NewLabel"
@@ -19,10 +19,13 @@ type ArticleCardProps = {
    * インデックス
    */
   index: number
+  /**
+   * ロケール
+   */
+  locale: string
 }
 
-const ArticleCard = ({ data, index }: ArticleCardProps) => {
-  const locale = useLocale();
+const ArticleCard = ({ data, index, locale }: ArticleCardProps) => {
   const t = useTranslations('blog');
   const categoryId = getPrimaryCategoryId(data);
   const blogPath = getBlogPath(locale, categoryId, data.id);

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -30,7 +30,7 @@ const ArticleList = async ({ query, blogType, page, basePath, locale }: ArticleL
         <ul className="flex-imtem grid grid-cols-1 xl:grid-cols-2 gap-4">
           {data.contents.map((item: BlogsContentType, index: number) => (
             <li key={item.id} data-testid={`pw-article-card-${index}`}>
-              <ArticleCard data={item} index={index} />
+              <ArticleCard data={item} index={index} locale={locale} />
             </li>
           ))}
           {Array.from({ length: emptyItem }).map((_, index) => (

--- a/src/components/SearchStateCard/index.stories.tsx
+++ b/src/components/SearchStateCard/index.stories.tsx
@@ -24,19 +24,22 @@ type Story = StoryObj<typeof meta>;
 
 export const KeyWord: Story = {
   args: {
-    keyword: "キーワード"
+    keyword: "キーワード",
+    locale: "ja"
   }
 };
 
 export const Category: Story = {
   args: {
-    category: "TypeScript"
+    category: "TypeScript",
+    locale: "ja"
   }
 };
 
 export const Both: Story = {
   args: {
     keyword: "テストキーワード",
-    category: "Next.js"
+    category: "Next.js",
+    locale: "ja"
   }
 };

--- a/src/components/SearchStateCard/index.tsx
+++ b/src/components/SearchStateCard/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Link } from 'next-view-transitions';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import Chip from "@/components/UiParts/Chip";
 import type { MappedKeyLiteralType } from "@/types/microcms";
 import { CATEGORY_MAPED_ID } from "@/static/blogs";
@@ -15,10 +15,13 @@ type SearchStateCardProps = {
    * カテゴリー
    */
   category?: MappedKeyLiteralType | string
+  /**
+   * ロケール
+   */
+  locale: string
 }
 
-const SearchStateCard = ({ keyword, category }: SearchStateCardProps) => {
-  const locale = useLocale();
+const SearchStateCard = ({ keyword, category, locale }: SearchStateCardProps) => {
   const t = useTranslations('blog');
   const tCategories = useTranslations('categories');
   

--- a/src/components/UiParts/BlogTypeTabs/index.stories.tsx
+++ b/src/components/UiParts/BlogTypeTabs/index.stories.tsx
@@ -31,13 +31,15 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    "blogType": "blogs"
+    "blogType": "blogs",
+    "locale": "ja"
   }
 }
 
 export const ZennTab: Story = {
   args: {
-    "blogType": "zenn"
+    "blogType": "zenn",
+    "locale": "ja"
   },
   parameters: {
     // NOTE: useSearchParamsが機能できるように設定

--- a/src/components/UiParts/BlogTypeTabs/index.tsx
+++ b/src/components/UiParts/BlogTypeTabs/index.tsx
@@ -3,7 +3,6 @@ import { GlobalContext } from '@/providers';
 import { BLOG_TYPE_ASSETS, BlogTypeKeyLIteralType } from '@/types';
 import { cltw } from '@/util';
 import { useRouter } from 'next/navigation';
-import { useLocale } from 'next-intl';
 import React, { useCallback, useContext, useState } from 'react';
 
 type BlogTypeTabsProps = {
@@ -11,12 +10,15 @@ type BlogTypeTabsProps = {
    * 一覧表示するブログの種類
    */
   blogType: BlogTypeKeyLIteralType;
+  /**
+   * ロケール
+   */
+  locale: string;
 }
 
-const BlogTypeTabs = ({ blogType }: BlogTypeTabsProps) => {
+const BlogTypeTabs = ({ blogType, locale }: BlogTypeTabsProps) => {
   const { dispatch } = useContext(GlobalContext);
   const [activeTab, setActiveTab] = useState<BlogTypeKeyLIteralType>(blogType || "blogs");
-  const locale = useLocale();
   const router = useRouter();
 
   const blogButtonHandler = useCallback(() => {


### PR DESCRIPTION
setRequestLocaleでページが表示されない問題を受け、参考記事のProps-based方式に変更:

- 各ページコンポーネントからsetRequestLocale()を削除
- useLocale()をクライアントコンポーネントから削除
- 主要コンポーネントにlocale propsを追加:
  - SearchStateCard: locale propsでリンク生成とテキスト表示
  - BlogTypeTabs: locale propsでナビゲーション制御
  - ArticleCard: locale propsでブログパス生成
- 親コンポーネントから子コンポーネントへlocaleを伝播
- Storybookストーリーにもlocale propsを追加

静的生成(SSG)を維持し、CloudFrontキャッシュとの互換性を確保
103ページすべての事前生成を確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)