### PR TITLE
fix: App Runnerドメイン露出とRSCハイドレーションエラーを修正

### DIFF
--- a/src/components/Footer/FooterNav/index.tsx
+++ b/src/components/Footer/FooterNav/index.tsx
@@ -1,7 +1,7 @@
 import ExternalLink from "@/components/UiParts/ExternalLink";
 import Tooltip from "@/components/UiParts/Tooltip";
 import type { HeaderNavItem } from "@/types/header";
-import { Link } from 'next-view-transitions';
+import { Link } from '@/i18n/navigation';
 
 type FooterNavProps = {
   items: HeaderNavItem[];
@@ -24,7 +24,7 @@ const FooterNav = ({ items, locale }: FooterNavProps) => {
             </li>
             :
             <li key={index} className="min-w-20 flex justify-center md:text-start text-gray-600 dark:text-gray-400">
-              <Link href={href.startsWith('/') && locale ? `/${locale}${href}` : href} prefetch={false} className="block px-2 py-3 transition duration-200 hover:text-base-color hover:underline hover:underline-offset-2 hover:decoration-base-color">
+              <Link href={href} prefetch={false} className="block px-2 py-3 transition duration-200 hover:text-base-color hover:underline hover:underline-offset-2 hover:decoration-base-color">
                 {name}
               </Link>
             </li>

--- a/src/components/Header/LocaleAwareHeaderNav.tsx
+++ b/src/components/Header/LocaleAwareHeaderNav.tsx
@@ -1,7 +1,7 @@
 import ExternalLink from "@/components/UiParts/ExternalLink";
 import Tooltip from "@/components/UiParts/Tooltip";
 import type { HeaderNavItem } from "@/types/header";
-import { Link } from 'next-view-transitions';
+import { Link } from '@/i18n/navigation';
 
 type HeaderNavProps = {
   items: HeaderNavItem[];
@@ -24,7 +24,7 @@ const LocaleAwareHeaderNav = ({ items, locale }: HeaderNavProps) => {
             </li>
             :
             <li key={index} className=" text-gray-600 dark:text-gray-400 transition duration-200 hover:text-base-color hover:underline hover:underline-offset-2 hover:decoration-base-color">
-              <Link href={href.startsWith('/') && locale ? `/${locale}${href}` : href}>
+              <Link href={href}>
                 {name}
               </Link>
             </li>

--- a/src/components/Header/SPNav/NavDrower/index.tsx
+++ b/src/components/Header/SPNav/NavDrower/index.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { Link } from 'next-view-transitions';
+import { Link } from '@/i18n/navigation';
 
 import SocialMediaNav from "@/components/Header/SocialMediaNav";
 import ExternalLink from "@/components/UiParts/ExternalLink";
@@ -24,7 +24,7 @@ const NavDrower = ({ isOpen, items, locale, onClick }: NavDrowerProps) => {
                 <span className="mx-4">{name}</span>
               </ExternalLink>
               :
-              <Link key={index} href={href.startsWith('/') && locale ? `/${locale}${href}` : href} className="block py-2.5 px-0 transition dark:text-gray-300 duration-200 hover:bg-light dark:hover:bg-primary hover:text-white">
+              <Link key={index} href={href} className="block py-2.5 px-0 transition dark:text-gray-300 duration-200 hover:bg-light dark:hover:bg-primary hover:text-white">
                 <span className="mx-4">{name}</span>
               </Link>
           ))}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,16 +11,17 @@ const intlMiddleware = createMiddleware(routing);
 export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   
+  // AWS App Runnerのホスト名を先にチェック
+  if (request.nextUrl.hostname.includes('awsapprunner')) {
+    // 正しいドメインにリダイレクト
+    return NextResponse.redirect(new URL(pathname, 'https://ryotablog.jp'))
+  }
+  
   // CloudFront経由のアクセスの場合、正しいホスト名を取得
   const forwardedHost = request.headers.get('x-forwarded-host');
-  const host = forwardedHost || request.headers.get('host') || request.nextUrl.host;
+  const host = forwardedHost || 'ryotablog.jp'; // デフォルトを正しいドメインに
   const protocol = request.headers.get('x-forwarded-proto') || 'https';
   const baseUrl = `${protocol}://${host}`;
-  
-  // AWS App Runnerのホスト名をブロック
-  if (request.nextUrl.hostname.includes('awsapprunner')) {
-    return NextResponse.redirect(new URL('/404', baseUrl))
-  }
 
   // ルートパスを処理 - 保存されたlocale設定またはデフォルトlocaleにリダイレクト
   if (pathname === '/') {


### PR DESCRIPTION
問題:
1. ヘッダー・フッターのナビゲーションリンクからApp Runnerドメインにリダイレクトされ、WAFで拒否される
2. 詳細ページへの遷移時にページが白紙になりRSCストリーミングエラーが発生

原因:
1. middleware.tsでApp Runnerホスト名チェックが遅く、baseUrlに内部ドメインが含まれていた
2. next-view-transitionsとnext-intlのLinkコンポーネントが混在し、RSCで競合していた

解決策:
1. middleware.tsの修正
   - App Runnerホスト名チェックを最初に移動
   - デフォルトホスト名を'ryotablog.jp'に固定
   - App Runnerドメインアクセス時は正しいドメインにリダイレクト

2. Linkコンポーネントの統一
   - LocaleAwareHeaderNav、FooterNav、NavDrowerをnext-intl/navigationのLinkに変更
   - href処理を簡略化（next-intlが自動的にlocaleを処理）

結果:
- App Runnerドメインへのアクセスが防止される
- ヘッダー・フッターからのナビゲーションが正常に動作
- RSCハイドレーションエラーが解消

🤖 Generated with [Claude Code](https://claude.ai/code)