### PR TITLE
fix: Linkコンポーネントの統一でRSCハイドレーションエラーを解決

### DIFF
--- a/src/components/CategoryList/CategoryItem/index.tsx
+++ b/src/components/CategoryList/CategoryItem/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Link } from 'next-view-transitions';
+import { Link } from '@/i18n/navigation';
 import { useLocale } from 'next-intl';
 
 type CategoryItemProps = {
@@ -19,7 +19,7 @@ const CategoryItem = ({ id, categoryName }: CategoryItemProps) => {
   
   return (
     <li className="flex items-center justify-center md:justify-start gap-2">
-      <Link href={`/${locale}/blogs/${id}`} className="md:w-full h-full p-2 md:p-4 block text-white md:text-txt-base dark:md:text-gray-500 text-md leading-tight font-medium bg-secondary md:bg-transparent rounded-full md:rounded-none transition duration-200 hover:text-base-color dark:md:hover:text-primary dark:hover:text-gray-100 dark:hover:opacity-90" data-testid={`pw-category-list-${id}`}>
+      <Link href={`/blogs/${id}`} className="md:w-full h-full p-2 md:p-4 block text-white md:text-txt-base dark:md:text-gray-500 text-md leading-tight font-medium bg-secondary md:bg-transparent rounded-full md:rounded-none transition duration-200 hover:text-base-color dark:md:hover:text-primary dark:hover:text-gray-100 dark:hover:opacity-90" data-testid={`pw-category-list-${id}`}>
         <p>{categoryName}</p>
       </Link>
     </li>

--- a/src/components/Pagination/EllipsisMenu/EllipsisMenuItem/index.tsx
+++ b/src/components/Pagination/EllipsisMenu/EllipsisMenuItem/index.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { Link } from "next-view-transitions"
+import { Link } from '@/i18n/navigation'
 import { useSearchParams, usePathname } from "next/navigation"
 import { useCallback, type ReactNode } from "react"
 import { cltw } from "@/util"
@@ -14,12 +14,11 @@ const EllipsisMenuItem = ({ pageNumber, children }: EllipsisMenuItemProps) => {
   const pathname = usePathname()
 
   const generateHref = useCallback(() => {
-    // 国際化対応: カテゴリページかどうかを確認
-    const categoryPathMatch = pathname.match(/^\/([^\/]+)\/blogs\/([^\/]+)$/)
-    const locale = categoryPathMatch ? categoryPathMatch[1] : pathname.match(/^\/([^\/]+)/)?.[1] || 'ja'
-    const categoryId = categoryPathMatch ? categoryPathMatch[2] : null
+    // カテゴリページかどうかを確認（localeプレフィックスなし）
+    const categoryPathMatch = pathname.match(/^\/[^\/]+\/blogs\/([^\/]+)$/)
+    const categoryId = categoryPathMatch ? categoryPathMatch[1] : null
     
-    let baseHref = categoryId ? `/${locale}/blogs/${categoryId}` : `/${locale}/blogs`
+    let baseHref = categoryId ? `/blogs/${categoryId}` : `/blogs`
     const keyword = searchParams?.get('keyword') ?? ""
 
     if (keyword) {

--- a/src/components/Pagination/PaginationItem/index.tsx
+++ b/src/components/Pagination/PaginationItem/index.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { cltw } from "@/util"
-import { Link } from "next-view-transitions"
-import { useRouter, useSearchParams, usePathname } from "next/navigation"
+import { Link } from '@/i18n/navigation'
+import { useSearchParams, usePathname } from "next/navigation"
 import { ReactNode, useCallback } from "react"
 import { CATEGORY_MAPED_ID } from "@/static/blogs"
 
@@ -27,14 +27,13 @@ const PaginationItem = ({ pageNumber, children, currentPage, basePath }: Paginat
       return `${basePath}/page/${pageNumber}`
     }
 
-    // 国際化対応: カテゴリページかどうかを確認
-    const categoryPathMatch = pathname?.match(/^\/([^\/]+)\/blogs\/([^\/]+)$/)
-    const locale = categoryPathMatch ? categoryPathMatch[1] : pathname?.match(/^\/([^\/]+)/)?.[1] || 'ja'
-    const categoryId = categoryPathMatch ? categoryPathMatch[2] : null
+    // カテゴリページかどうかを確認（localeプレフィックスなし）
+    const categoryPathMatch = pathname?.match(/^\/[^\/]+\/blogs\/([^\/]+)$/)
+    const categoryId = categoryPathMatch ? categoryPathMatch[1] : null
     
     const keyword = searchParams?.get('keyword') ?? ""
     
-    let baseHref = categoryId ? `/${locale}/blogs/${categoryId}` : `/${locale}/blogs`
+    let baseHref = categoryId ? `/blogs/${categoryId}` : `/blogs`
 
     if (keyword) {
       const currentPath = `${baseHref}?keyword=${keyword}`

--- a/src/static/footer.ts
+++ b/src/static/footer.ts
@@ -4,11 +4,11 @@ import type { FooterNavItem } from "@/types/footer";
 export const getFooterNavItems = (locale: string): FooterNavItem[] => [
   {
     name: 'Home',
-    href: `/${locale}/blogs`,
+    href: '/blogs',
   },
   {
     name: 'About',
-    href: `/${locale}/about`,
+    href: '/about',
   },
   {
     name: 'Contact',
@@ -22,11 +22,11 @@ export const getFooterNavItems = (locale: string): FooterNavItem[] => [
   },
   {
     name: "RSS",
-    href: `/${locale}/feed`,
+    href: "/feed",
   },
   {
     name: "llms.txt",
-    href: `/${locale}/docs/llms.txt`,
+    href: "/docs/llms.txt",
   }
 ] as const;
 

--- a/src/static/header.ts
+++ b/src/static/header.ts
@@ -4,11 +4,11 @@ import type { HeaderNavItem } from "@/types/header";
 export const getHeaderNavItems = (locale: string): HeaderNavItem[] => [
   {
     name: 'Home',
-    href: `/${locale}`,
+    href: '/',
   },
   {
     name: 'About',
-    href: `/${locale}/about`,
+    href: '/about',
   },
   {
     name: 'Contact',
@@ -44,13 +44,13 @@ export const getSocialMediaNavItems = (locale: string): HeaderNavItem[] => [
   },
   {
     name: "Feed",
-    href: `/${locale}/feed`,
+    href: "/feed",
     icon: "/icons/rss.webp",
     target: "_self",
   },
   {
     name: "LLMs",
-    href: `/${locale}/docs/llms.txt`,
+    href: "/docs/llms.txt",
     icon: "/icons/llms.png",
     target: "_self",
   }


### PR DESCRIPTION
問題:
- ページネーション、カテゴリリスト、ナビゲーション設定でnext-view-transitionsとnext-intlのLinkが混在
- 異なるLinkコンポーネントの使用によりRSCハイドレーションエラーが発生
- 一部のナビゲーションリンクでRSCペイロードが生テキストとして表示

変更内容:
1. Linkコンポーネントの統一
   - PaginationItem: next-view-transitions → @/i18n/navigation
   - EllipsisMenuItem: next-view-transitions → @/i18n/navigation
   - CategoryItem: next-view-transitions → @/i18n/navigation

2. ナビゲーション設定の最適化
   - header.ts/footer.ts: localeプレフィックスを削除
   - next-intlが自動的にlocale処理を行うよう変更

3. href生成ロジックの簡略化
   - 手動のlocale追加処理を削除
   - /blogs/${category} 形式に統一

結果:
- 全てのリンクが@/i18n/navigationのLinkを使用
- RSCハイドレーションエラーが解消
- ページ遷移が正常に動作

🤖 Generated with [Claude Code](https://claude.ai/code)