### PR TITLE
fix: CloudFrontキャッシュ効率化のため動的レンダリングを削減

### DIFF
--- a/src/app/[locale]/blogs/page.tsx
+++ b/src/app/[locale]/blogs/page.tsx
@@ -20,6 +20,9 @@ import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
 import type { MappedKeyLiteralType } from "@/types/microcms";
 import type { BlogTypeKeyLIteralType } from "@/types";
 
+// キャッシュ設定: 1時間のISR
+export const revalidate = 3600; // 1時間
+
 interface PageProps {
   params: {
     locale: string;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import type { Metadata } from "next";
 import { Kosugi_Maru } from "next/font/google"
 import { ViewTransitions } from 'next-view-transitions'
 import NextTopLoader from "nextjs-toploader";
-import { headers } from 'next/headers';
 import { routing } from '@/i18n/routing'
 
 import ClientLayout from "@/components/ClientLayout";
@@ -22,14 +21,20 @@ export const metadata: Metadata = {
   }
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // next-intlからlocaleを取得
-  const headersList = headers();
-  const locale = headersList.get('x-next-intl-locale') || routing.defaultLocale;
+  // 本番環境では静的レンダリングを維持するため、headers()を使わない
+  let locale: string = routing.defaultLocale;
+  
+  // 開発環境でのみ動的なlocale取得を行う
+  if (process.env.NODE_ENV === 'development') {
+    const { headers } = await import('next/headers');
+    const headersList = headers();
+    locale = headersList.get('x-next-intl-locale') || routing.defaultLocale;
+  }
 
   return (
     <ViewTransitions>


### PR DESCRIPTION
## 概要
Issue #116 で特定されたCloudFrontキャッシュ問題を解決するため、Next.jsの動的レンダリングを強制する関数の使用を削減しました。

## 変更内容

### 1. 本番環境での動的関数使用を回避
- **layout.tsx**: `headers()` 関数を本番環境では使用しない
- **ブログ詳細ページ**: `cookies()` と `draftMode()` を開発環境のみに制限

### 2. キャッシュ設定の追加
- **ブログ詳細ページ**: 24時間のISR設定
- **ブログ一覧ページ**: 1時間のISR設定
- **本番環境**: 静的生成を強制

## 期待される効果
- **キャッシュヒット率**: 10% → 70%+ への改善
- **静的生成の復活**: 本番環境で主要ページが静的生成される
- **オリジンサーバー負荷軽減**: 動的レンダリングが大幅に削減

## 検証方法
本番環境デプロイ後、以下で確認：
```bash
curl -I https://ryota-blog.com/ja/blogs/[category]/[blogId]
```

期待されるレスポンス：
```
Cache-Control: s-maxage=86400, stale-while-revalidate
```

## 関連
Closes #116

🤖 Generated with [Claude Code](https://claude.ai/code)