### PR TITLE
fix: GitHub Actionsでryota-blog-prdサービスを明示的に選択するよう修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,13 +124,15 @@ jobs:
           echo "AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID" >> $GITHUB_OUTPUT
           echo "検出されたAWSアカウントID: $AWS_ACCOUNT_ID"
           
-          # App Runnerサービス一覧を取得（最新のサービスを使用）
+          # App Runnerサービス一覧を取得（ryota-blog-prdサービスを使用）
           SERVICE_ARN=$(aws apprunner list-services \
-            --query 'ServiceSummaryList[0].ServiceArn' \
+            --query 'ServiceSummaryList[?ServiceName==`ryota-blog-prd`].ServiceArn' \
             --output text)
           
+          # ryota-blog-prdサービスが見つからない場合のエラーメッセージを改善
           if [ "$SERVICE_ARN" = "None" ] || [ -z "$SERVICE_ARN" ]; then
-            echo "❌ App Runnerサービスが見つかりません"
+            echo "❌ ryota-blog-prdサービスが見つかりません。利用可能なサービス一覧:"
+            aws apprunner list-services --query 'ServiceSummaryList[*].ServiceName' --output text
             exit 1
           fi
           


### PR DESCRIPTION
## Summary
- GitHub ActionsのApp Runnerサービス選択ロジックを修正
- 最初のサービス（multi-spa-app-dev-api）が誤選択される問題を解決
- JMESPathクエリでryota-blog-prdサービスを明示的に指定

## Changes
- `ServiceSummaryList[0].ServiceArn` → `ServiceSummaryList[?ServiceName==\`ryota-blog-prd\`].ServiceArn`
- エラーメッセージを改善し、利用可能なサービス一覧を表示
- コメントを更新して対象サービスを明確化

## Test Plan
- [x] AWS CLIコマンドが正しいサービスARNを返すことを確認
- [ ] 次回のデプロイメントで正しいサービスが選択されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)