### PR TITLE
fix: RSCペイロードのContent-Type設定を追加してプレーンテキスト表示問題を解決

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,30 @@ const nextConfig = {
     deviceSizes: [640, 768, 1024, 1280, 1536],
     imageSizes: [16, 32, 48, 64, 96],
   },
+  async headers() {
+    return [
+      {
+        // RSCリクエストの識別（_rscクエリパラメータ）
+        source: '/:path*',
+        has: [
+          {
+            type: 'query',
+            key: 'rsc',
+          },
+        ],
+        headers: [
+          {
+            key: 'Content-Type',
+            value: 'text/x-component; charset=utf-8'
+          },
+          {
+            key: 'Cache-Control',
+            value: 'no-store'
+          }
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       // Redirect /blogs/page to /blogs


### PR DESCRIPTION
## 概要
GitHub Issue #123で報告されたRSCペイロードがプレーンテキストとして表示される問題を修正しました。

## 修正内容
- next.config.mjsにRSCリクエスト用のheaders設定を追加
- RSCリクエスト（?rscクエリパラメータ）に適切なContent-Type（text/x-component）を設定
- Cache-Control: no-storeでキャッシュ競合を回避
- Next.js 14.2.3対応の正しい設定を実装

## 対象URL
- https://ryotablog.jp/ja/blogs/release_notes/release-notes-202505

## 検証結果
- ✅ ビルド正常完了
- ✅ 開発サーバーでの動作確認
- ✅ 型チェック実行（メインソースコードには型エラーなし）

## 関連Issue
- Closes #123

🤖 Generated with [Claude Code](https://claude.ai/code)