### PR TITLE
fix: RSCクエリパラメータを_rscに修正してペイロード表示問題を解決

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,7 +22,7 @@ const nextConfig = {
         has: [
           {
             type: 'query',
-            key: 'rsc',
+            key: '_rsc',
           },
         ],
         headers: [


### PR DESCRIPTION
- next.config.mjsのRSCリクエスト識別で'rsc'を'_rsc'に修正
- Next.jsが実際に使用する正しいクエリパラメータに対応
- ブログ詳細ページでのリロード時RSCペイロード表示問題を修正
- CloudFrontキャッシュ問題の根本原因を解決

関連: GitHub Issue #123

🤖 Generated with [Claude Code](https://claude.ai/code)