### PR TITLE
fix: /blogsページでのRSCペイロード問題を解決

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,30 +14,31 @@ const nextConfig = {
     deviceSizes: [640, 768, 1024, 1280, 1536],
     imageSizes: [16, 32, 48, 64, 96],
   },
-  async headers() {
-    return [
-      {
-        // RSCリクエストの識別（_rscクエリパラメータ）
-        source: '/:path*',
-        has: [
-          {
-            type: 'query',
-            key: '_rsc',
-          },
-        ],
-        headers: [
-          {
-            key: 'Content-Type',
-            value: 'text/x-component; charset=utf-8'
-          },
-          {
-            key: 'Cache-Control',
-            value: 'no-store'
-          }
-        ],
-      },
-    ];
-  },
+  // NOTE: RSCペイロード問題解決のため一時的にheaders設定を無効化
+  // async headers() {
+  //   return [
+  //     {
+  //       // RSCリクエストの識別（_rscクエリパラメータ）
+  //       source: '/:path*',
+  //       has: [
+  //         {
+  //           type: 'query',
+  //           key: '_rsc',
+  //         },
+  //       ],
+  //       headers: [
+  //         {
+  //           key: 'Content-Type',
+  //           value: 'text/x-component; charset=utf-8'
+  //         },
+  //         {
+  //           key: 'Cache-Control',
+  //           value: 'no-store'
+  //         }
+  //       ],
+  //     },
+  //   ];
+  // },
   async redirects() {
     return [
       // Redirect /blogs/page to /blogs

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -28,7 +28,6 @@ const SearchBar = () => {
 
     if (!keyword) {
       router.push(categoryId ? `/${locale}/blogs/${categoryId}` : `/${locale}/blogs`)
-      router.refresh()
       return
     }
 
@@ -37,13 +36,11 @@ const SearchBar = () => {
     if (categoryId) {
       formRef.current?.reset()
       router.push(`/${locale}/blogs/${categoryId}?keyword=${escapedKeyword}`)
-      router.refresh()
       return
     }
 
     formRef.current?.reset()
     router.push(`/${locale}/blogs?keyword=${escapedKeyword}`)
-    router.refresh()
   }
 
   return (


### PR DESCRIPTION
- next.config.mjsのheaders設定を一時的に無効化してContent-Type競合を回避
- SearchBarのrouter.refresh()呼び出しを削除してRSCペイロード問題を防止
- zenn、検索、i18nボタン押下時のplain textレスポンス問題を修正

関連: GitHub Issue #129

🤖 Generated with [Claude Code](https://claude.ai/code)