### PR TITLE
fix: RSCペイロード問題の修正 - Acceptヘッダーの正規表現を厳密化

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,7 +27,7 @@ const nextConfig = {
           {
             type: 'header',
             key: 'accept',
-            value: '.*text/x-component.*'
+            value: '^text/x-component.*'
           }
         ],
         headers: [


### PR DESCRIPTION
- Acceptヘッダーの判定を部分一致(.*text/x-component.*)から先頭一致(^text/x-component.*)に変更
- 特定のページ(/ja/blogs/terraform/apprunner-and-cloudfront-image-bugfix)でリロード時にRSCペイロードがプレーンテキストとして表示される問題を解決
- より厳密なRSCリクエスト判定により、誤ったContent-Type設定を防止

🤖 Generated with [Claude Code](https://claude.ai/code)