### PR TITLE
fix: /blogsページのRSCペイロード問題を解決

### DIFF
--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -27,7 +27,7 @@ const SearchBar = () => {
     const categoryId = categoryPathMatch ? categoryPathMatch[1] : null
 
     if (!keyword) {
-      router.push(categoryId ? `/${locale}/blogs/${categoryId}` : `/${locale}/blogs`)
+      router.replace(categoryId ? `/${locale}/blogs/${categoryId}` : `/${locale}/blogs`)
       return
     }
 
@@ -35,12 +35,12 @@ const SearchBar = () => {
 
     if (categoryId) {
       formRef.current?.reset()
-      router.push(`/${locale}/blogs/${categoryId}?keyword=${escapedKeyword}`)
+      router.replace(`/${locale}/blogs/${categoryId}?keyword=${escapedKeyword}`)
       return
     }
 
     formRef.current?.reset()
-    router.push(`/${locale}/blogs?keyword=${escapedKeyword}`)
+    router.replace(`/${locale}/blogs?keyword=${escapedKeyword}`)
   }
 
   return (

--- a/src/components/UiParts/BlogTypeTabs/index.tsx
+++ b/src/components/UiParts/BlogTypeTabs/index.tsx
@@ -2,8 +2,8 @@
 import { GlobalContext } from '@/providers';
 import { BLOG_TYPE_ASSETS, BlogTypeKeyLIteralType } from '@/types';
 import { cltw } from '@/util';
-import { useRouter } from 'next/navigation';
 import { useLocale } from 'next-intl';
+import Link from 'next/link';
 import React, { useCallback, useContext, useState } from 'react';
 
 type BlogTypeTabsProps = {
@@ -17,19 +17,16 @@ const BlogTypeTabs = ({ blogType }: BlogTypeTabsProps) => {
   const { dispatch } = useContext(GlobalContext);
   const [activeTab, setActiveTab] = useState<BlogTypeKeyLIteralType>(blogType || "blogs");
   const locale = useLocale();
-  const router = useRouter();
 
   const blogButtonHandler = useCallback(() => {
     setActiveTab("blogs")
     dispatch({ type: "SET_BLOG_TYPE", payload: { blogType: "blogs" } })
-    router.push(`/${locale}/blogs`)
-  }, [locale, dispatch, router])
+  }, [dispatch])
 
   const zennButtonHandler = useCallback(() => {
     setActiveTab("zenn")
     dispatch({ type: "SET_BLOG_TYPE", payload: { blogType: "zenn" } })
-    router.push(`/${locale}/blogs/zenn`)
-  }, [locale, dispatch, router])
+  }, [dispatch])
 
 
   return (
@@ -40,22 +37,22 @@ const BlogTypeTabs = ({ blogType }: BlogTypeTabsProps) => {
           transform: activeTab === "blogs" ? 'translateX(0%)' : 'translateX(100%)',
         }}
       />
-      <button
-        type='button'
-        className={cltw("relative z-10 px-4 py-2 transition-all duration-300 text-center w-1/2 font-medium text-lg text-txt-base", activeTab === "blogs" ? "" : "text-txt-base dark:text-gray-400")}
+      <Link
+        href={`/${locale}/blogs`}
+        className={cltw("relative z-10 px-4 py-2 transition-all duration-300 text-center w-1/2 font-medium text-lg text-txt-base flex items-center justify-center", activeTab === "blogs" ? "" : "text-txt-base dark:text-gray-400")}
         onClick={blogButtonHandler}
         data-testid="pw-blog-type-tabs-blogs"
       >
         {BLOG_TYPE_ASSETS["blogs"]}
-      </button>
-      <button
-        type='button'
-        className={cltw("relative z-10 px-4 py-2 transition-all duration-300 text-center w-1/2 font-medium text-lg text-txt-base", activeTab === "zenn" ? '' : 'dark:text-gray-400')}
+      </Link>
+      <Link
+        href={`/${locale}/blogs/zenn`}
+        className={cltw("relative z-10 px-4 py-2 transition-all duration-300 text-center w-1/2 font-medium text-lg text-txt-base flex items-center justify-center", activeTab === "zenn" ? '' : 'dark:text-gray-400')}
         onClick={zennButtonHandler}
         data-testid="pw-blog-type-tabs-zenn"
       >
         {BLOG_TYPE_ASSETS["zenn"]}
-      </button>
+      </Link>
     </nav>
   );
 };

--- a/src/hooks/useLanguageSwitch.ts
+++ b/src/hooks/useLanguageSwitch.ts
@@ -21,7 +21,7 @@ export const useLanguageSwitch = () => {
     try {
       const newPath = generateLocalePath(pathname, locale, targetLocale);
       saveLocaleToCookie(targetLocale);
-      router.push(newPath);
+      router.replace(newPath);
       setIsOpen(false);
     } catch (error) {
       console.error("言語切り替えに失敗しました:", error);


### PR DESCRIPTION
- BlogTypeTabsコンポーネント: router.pushをLinkコンポーネントに変更してソフトナビゲーションを維持
- SearchBarコンポーネント: router.pushをrouter.replaceに変更してRSCペイロード問題を回避
- useLanguageSwitchフック: router.pushをrouter.replaceに変更して言語切り替え時の問題を解決

これによりZennボタン、検索ボタン、言語切り替えボタンが正常に動作するようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)