### PR TITLE
chore: Storybook を Cloudflare Pages にデプロイするワークフロー追加

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,37 @@
+name: Deploy Storybook to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**/*.stories.*'
+      - 'src/**/*.mdx'
+      - '.storybook/**'
+      - '.github/workflows/deploy-storybook.yml'
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy storybook-static --project-name=ryota-blog-storybook

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 .wrangler/
 .dev.vars
 
+# storybook
+storybook-static/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts


### PR DESCRIPTION
stories/mdx/.storybook の変更時にmainブランチへのpushで自動デプロイ。 wrangler pages deployでstorybook-staticをryota-blog-storybookプロジェクトにデプロイ。