### PR TITLE
fix: Storybook Vite環境向けにnext/image, next/linkのモックを追加

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,12 +24,15 @@ const config: StorybookConfig = {
   typescript: {
     reactDocgen: "react-docgen-typescript"
   },
-  // tsconfigのpaths(@/*)をViteで解決するためのエイリアス設定
+  // tsconfigのpaths(@/*)とNext.jsモジュールをViteで解決するためのエイリアス設定
   viteFinal: async (config) => {
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...config.resolve.alias,
       "@": path.resolve(__dirname, "../src"),
+      // Next.jsモジュールのモック（Vite環境では動作しないため）
+      "next/image": path.resolve(__dirname, "./mocks/next-image.tsx"),
+      "next/link": path.resolve(__dirname, "./mocks/next-link.tsx"),
     };
     return config;
   },

--- a/.storybook/mocks/next-image.tsx
+++ b/.storybook/mocks/next-image.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+// next/image の Storybook 用モック（Vite環境では next/image が動作しないため）
+const MockImage = (props: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean }) => {
+  const { fill, ...rest } = props;
+  // fill プロパティが指定されている場合は、親要素に合わせて表示
+  const style = fill
+    ? { position: "absolute" as const, width: "100%", height: "100%", objectFit: "cover" as const }
+    : {};
+  // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+  return <img {...rest} style={{ ...style, ...((rest.style as React.CSSProperties) || {}) }} />;
+};
+
+export default MockImage;

--- a/.storybook/mocks/next-link.tsx
+++ b/.storybook/mocks/next-link.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+// next/link の Storybook 用モック
+const MockLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => {
+  return <a {...props}>{children}</a>;
+};
+
+export default MockLink;


### PR DESCRIPTION
@storybook/react-viteではnext/imageが動作しないため、
標準のimgタグに変換するモックコンポーネントを作成し、
viteFinalのresolve.aliasで差し替え。