### PR TITLE
fix: HTTPリクエストをHTTPSに永続リダイレクト

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,6 +28,20 @@ const nextConfig = {
   // カスタムheaders()でのオーバーライドは不要（Cloudflare Workersでリダイレクト時に問題を引き起こすため削除）
   async redirects() {
     return [
+      // HTTP で到達したリクエストを HTTPS に永続リダイレクト
+      // Cloudflare → Origin 間で http のまま渡されたケースをここで弾く（Search Console の HTTPS 評価対策）
+      {
+        source: '/:path*',
+        has: [
+          {
+            type: 'header',
+            key: 'x-forwarded-proto',
+            value: 'http',
+          },
+        ],
+        destination: 'https://ryotablog.jp/:path*',
+        permanent: true,
+      },
       // Redirect /blogs/page to /blogs
       {
         source: '/blogs/page',


### PR DESCRIPTION
Search Consoleで報告された「HTTPS が評価されていません」エラーへの対応。
Cloudflare→Origin間でhttpのまま到達したリクエストをnext.config.mjsの redirects()で308リダイレクトし、hreflangやlinkヘッダーがhttp://で出力 される問題を防ぐ。