### PR TITLE
fix: root パスの HTTPS リダイレクトで :path* がリテラル展開される不具合を修正

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,8 +30,10 @@ const nextConfig = {
     return [
       // HTTP で到達したリクエストを HTTPS に永続リダイレクト
       // Cloudflare → Origin 間で http のまま渡されたケースをここで弾く（Search Console の HTTPS 評価対策）
+      // OpenNext (Cloudflare Workers) の path-to-regexp で :path* の 0 個マッチが
+      // 展開されないため root パスは別エントリに分離
       {
-        source: '/:path*',
+        source: '/',
         has: [
           {
             type: 'header',
@@ -39,7 +41,19 @@ const nextConfig = {
             value: 'http',
           },
         ],
-        destination: 'https://ryotablog.jp/:path*',
+        destination: 'https://ryotablog.jp/',
+        permanent: true,
+      },
+      {
+        source: '/:path+',
+        has: [
+          {
+            type: 'header',
+            key: 'x-forwarded-proto',
+            value: 'http',
+          },
+        ],
+        destination: 'https://ryotablog.jp/:path+',
         permanent: true,
       },
       // Redirect /blogs/page to /blogs


### PR DESCRIPTION
OpenNext (Cloudflare Workers) の path-to-regexp 実装で :path* の 0 個マッチ時に パスパラメータが展開されず、Location ヘッダーに ":path*" リテラルがそのまま
入る不具合があった。root パス用エントリを分離し、サブパスは :path+ に変更。