### PR TITLE
feat: about ページを刷新（Hero / 自己紹介 / Mission / Career / Skills / Contact）

### DIFF
--- a/e2e/about.spec.ts
+++ b/e2e/about.spec.ts
@@ -3,29 +3,57 @@ import { test, expect } from '@playwright/test';
 test.describe('Aboutページのテスト', () => {
   test('ABOUT-01: プロフィール情報表示', async ({ page }) => {
     await page.goto('/about');
-    
+
     const profileName = await page.locator('h1').first();
     await expect(profileName).toBeVisible();
-    
+
     const profileDescription = await page.locator('p').first();
     await expect(profileDescription).toBeVisible();
-    
+
     const profileImage = await page.locator('img').first();
     await expect(profileImage).toBeVisible();
   });
 
   test('ABOUT-02: SNSリンク機能', async ({ page }) => {
     await page.goto('/about');
-    
+
     const socialLinks = await page.locator('a[href*="twitter.com"], a[href*="github.com"], a[href*="facebook.com"], a[href*="linkedin.com"]').first();
-    
+
     if (await socialLinks.count() > 0) {
       const href = await socialLinks.getAttribute('href');
       const target = await socialLinks.getAttribute('target');
-      
+
       expect(target).toBe('_blank');
-      
+
       expect(href).toMatch(/^https:\/\/(twitter|github|facebook|linkedin)\.com/);
     }
+  });
+
+  test('ABOUT-03: 主要セクションの h2 が並んでいる', async ({ page }) => {
+    await page.goto('/about');
+    // Projects / Credentials / Outputs / Now を除いた構成では 5 セクション分の h2 が並ぶ想定
+    const h2Count = await page.locator('h2').count();
+    expect(h2Count).toBeGreaterThanOrEqual(5);
+  });
+
+  test('ABOUT-04: キャリアタイムラインに3以上のエントリ', async ({ page }) => {
+    await page.goto('/about');
+    const items = page.locator('section[aria-labelledby="career-heading"] ol > li');
+    await expect(items.first()).toBeVisible();
+    const count = await items.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+
+  test('ABOUT-05: Contact セクションに連絡リンクが存在する', async ({ page }) => {
+    await page.goto('/about');
+    const contactLinks = page.locator('section[aria-labelledby="contact-heading"] a[href]');
+    const count = await contactLinks.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('ABOUT-08: 英語ロケール（/en/about）でも h1 が表示される', async ({ page }) => {
+    await page.goto('/en/about');
+    const h1 = page.locator('h1').first();
+    await expect(h1).toBeVisible();
   });
 });

--- a/locales/en.json
+++ b/locales/en.json
@@ -85,7 +85,7 @@
   "categories": {
     "python": "Python",
     "typescript": "TypeScript",
-    "css": "CSS", 
+    "css": "CSS",
     "next_js": "Next.js",
     "release_notes": "Release Notes",
     "aws": "AWS",
@@ -101,5 +101,9 @@
     "life_hack": "LifeHack",
     "news": "News",
     "terraform": "Terraform"
+  },
+  "about": {
+    "pageTitle": "Ryota — Software Engineer / Fullstack",
+    "pageDescription": "Fullstack software engineer at a Tokyo-based logistics startup, working across Next.js, TypeScript, and AWS. Writing about the kind of web development problems that don't fit cleanly in tutorials."
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -85,7 +85,7 @@
   },
   "categories": {
     "python": "Python",
-    "typescript": "TypeScript", 
+    "typescript": "TypeScript",
     "css": "CSS",
     "next_js": "Next.js",
     "release_notes": "Release Notes",
@@ -102,5 +102,9 @@
     "life_hack": "LifeHack",
     "news": "時事",
     "terraform": "Terraform"
+  },
+  "about": {
+    "pageTitle": "りょた — Software Engineer / フルスタックエンジニア",
+    "pageDescription": "東京の物流スタートアップで、Next.js / TypeScript / AWS を扱うフルスタックエンジニア。教育・SES・物流と3つの業界を渡り歩いてきました。「同じ場所で詰まった人の時間を5分でも短くする」をミッションに、業務で得た知見をブログで発信しています。"
   }
 }

--- a/src/app/[locale]/about/_components/AboutMeSection/index.tsx
+++ b/src/app/[locale]/about/_components/AboutMeSection/index.tsx
@@ -1,0 +1,31 @@
+import { pickLocalized } from "@/lib/i18n-utils";
+import { ABOUT_ME } from "@/static/about";
+import SectionHeading from "../SectionHeading";
+
+type AboutMeSectionProps = {
+  locale: string;
+};
+
+// 自己紹介セクション。3段落の本文 + 趣味の1行
+const AboutMeSection = ({ locale }: AboutMeSectionProps) => {
+  const paragraphs = pickLocalized(ABOUT_ME.paragraphs, locale);
+  const hobbies = pickLocalized(ABOUT_ME.hobbies, locale);
+  const eyebrow = locale === "en" ? "// About me" : "// About me";
+  const title = locale === "en" ? "About me" : "自己紹介";
+
+  return (
+    <section aria-labelledby="aboutme-heading" className="max-w-prose">
+      <SectionHeading id="aboutme-heading" eyebrow={eyebrow} title={title} />
+      <div className="mt-8 space-y-6 text-gray-700 dark:text-gray-300 leading-relaxed">
+        {paragraphs.map((p, i) => (
+          // .highlight クラスを本文の一部に当てるために静的データの HTML を流し込む
+          // データソースは静的ファイル限定なので XSS リスクなし
+          <p key={i} dangerouslySetInnerHTML={{ __html: p }} />
+        ))}
+      </div>
+      <p className="mt-6 text-sm text-gray-500">{hobbies}</p>
+    </section>
+  );
+};
+
+export default AboutMeSection;

--- a/src/app/[locale]/about/_components/CareerTimeline/TimelineItem/index.tsx
+++ b/src/app/[locale]/about/_components/CareerTimeline/TimelineItem/index.tsx
@@ -1,0 +1,54 @@
+import Chip from "@/components/UiParts/Chip";
+import { formatPeriod, pickLocalized } from "@/lib/i18n-utils";
+import type { TimelineEntry } from "@/types/about";
+
+type TimelineItemProps = {
+  entry: TimelineEntry;
+  locale: string;
+};
+
+// キャリアタイムラインの1エントリ
+const TimelineItem = ({ entry, locale }: TimelineItemProps) => {
+  const role = pickLocalized(entry.role, locale);
+  const org = pickLocalized(entry.org, locale);
+  const summary = pickLocalized(entry.summary, locale);
+
+  return (
+    <li className="relative pl-6">
+      {/* タイムラインの丸ドット。罫線と分離させるため白/黒のリングを付ける */}
+      <span
+        aria-hidden
+        className="absolute -left-[7px] top-2 h-3 w-3 rounded-full bg-base-color ring-4 ring-white dark:bg-primary dark:ring-black"
+      />
+      <p className="font-mono text-sm text-gray-500">{formatPeriod(entry.period, locale)}</p>
+      <h3 className="mt-1 text-lg font-semibold leading-snug">
+        {role}
+        <span className="block text-sm font-normal text-gray-500 sm:ml-2 sm:inline">
+          @ {org}
+        </span>
+      </h3>
+      <ul className="mt-3 space-y-2 text-gray-700 dark:text-gray-300 leading-relaxed">
+        {summary.map((s) => (
+          <li key={s} className="flex gap-2">
+            <span aria-hidden className="shrink-0 text-gray-400">
+              —
+            </span>
+            <span>{s}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {entry.domains.map((d) => (
+          <Chip
+            key={d}
+            label={d}
+            noTruncate
+            classes="bg-light/40 dark:bg-primary/20 text-txt-base dark:text-gray-100 px-2 py-0.5 text-[11px] font-mono min-w-0"
+          />
+        ))}
+      </div>
+    </li>
+  );
+};
+
+export default TimelineItem;

--- a/src/app/[locale]/about/_components/CareerTimeline/index.tsx
+++ b/src/app/[locale]/about/_components/CareerTimeline/index.tsx
@@ -1,0 +1,25 @@
+import { TIMELINE } from "@/static/about";
+import SectionHeading from "../SectionHeading";
+import TimelineItem from "./TimelineItem";
+
+type CareerTimelineProps = {
+  locale: string;
+};
+
+// キャリアタイムラインのセクション
+const CareerTimeline = ({ locale }: CareerTimelineProps) => {
+  const title = locale === "en" ? "Career" : "これまでの歩み";
+
+  return (
+    <section aria-labelledby="career-heading">
+      <SectionHeading id="career-heading" eyebrow="// Career" title={title} />
+      <ol className="relative mt-8 ml-2 space-y-10 border-l-2 border-base-color/60 dark:border-primary/60">
+        {TIMELINE.map((entry) => (
+          <TimelineItem key={entry.id} entry={entry} locale={locale} />
+        ))}
+      </ol>
+    </section>
+  );
+};
+
+export default CareerTimeline;

--- a/src/app/[locale]/about/_components/ContactSection/index.tsx
+++ b/src/app/[locale]/about/_components/ContactSection/index.tsx
@@ -1,0 +1,95 @@
+import { FileText, Mail, MessageSquare } from "lucide-react";
+import { pickLocalized } from "@/lib/i18n-utils";
+import { CONTACT } from "@/static/about";
+import type { ContactChannelKind } from "@/types/about";
+import SectionHeading from "../SectionHeading";
+
+type ContactSectionProps = {
+  locale: string;
+};
+
+// 連絡手段ごとのアイコン
+const iconFor = (kind: ContactChannelKind) => {
+  if (kind === "email") return Mail;
+  if (kind === "form") return FileText;
+  return MessageSquare;
+};
+
+// 連絡・お仕事相談セクション
+const ContactSection = ({ locale }: ContactSectionProps) => {
+  const intro = pickLocalized(CONTACT.intro, locale);
+  const accepted = pickLocalized(CONTACT.acceptedTopics, locale);
+  const declined = pickLocalized(CONTACT.declinedTopics, locale);
+  const labels = {
+    title: locale === "en" ? "Contact" : "連絡・お仕事のご相談",
+    accepted: locale === "en" ? "Welcome to discuss" : "得意な相談ジャンル",
+    declined: locale === "en" ? "Not the best fit" : "お受けしづらいもの",
+    responseSla: locale === "en" ? "Response time" : "返信目安",
+  };
+
+  return (
+    <section aria-labelledby="contact-heading">
+      <SectionHeading id="contact-heading" eyebrow="// Contact" title={labels.title} />
+      <div className="mt-8 grid gap-8 md:grid-cols-[2fr_1fr]">
+        <div className="max-w-prose space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed">
+          {intro.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+          <div className="mt-6">
+            <p className="mb-2 font-semibold text-gray-900 dark:text-gray-100">{labels.accepted}</p>
+            <ul className="space-y-1.5 text-sm">
+              {accepted.map((t) => (
+                <li key={t} className="flex gap-2">
+                  <span aria-hidden className="text-base-color dark:text-primary">✓</span>
+                  {t}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="mt-4">
+            <p className="mb-2 font-semibold text-gray-500">{labels.declined}</p>
+            <ul className="space-y-1.5 text-sm text-gray-500">
+              {declined.map((t) => (
+                <li key={t} className="flex gap-2">
+                  <span aria-hidden>×</span>
+                  {t}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <aside className="space-y-3">
+          {CONTACT.channels.map((c) => {
+            const extraAttrs =
+              c.kind === "email"
+                ? {}
+                : { target: "_blank" as const, rel: "noopener noreferrer" as const };
+            const Icon = iconFor(c.kind);
+            return (
+              <a
+                key={c.kind}
+                href={c.href}
+                {...extraAttrs}
+                className="flex items-center gap-3 rounded border border-gray-200 p-4 transition-colors duration-200 hover:border-base-color dark:border-gray-700 dark:hover:border-primary"
+              >
+                <Icon
+                  aria-hidden
+                  className="h-5 w-5 shrink-0 text-primary dark:text-base-color"
+                />
+                <div className="min-w-0">
+                  <p className="font-mono text-xs uppercase tracking-wider text-gray-500">{c.kind}</p>
+                  <p className="mt-1 font-medium">{pickLocalized(c.label, locale)}</p>
+                </div>
+              </a>
+            );
+          })}
+          <p className="mt-4 font-mono text-xs text-gray-500">
+            {labels.responseSla}: {pickLocalized(CONTACT.responseSla, locale)}
+          </p>
+        </aside>
+      </div>
+    </section>
+  );
+};
+
+export default ContactSection;

--- a/src/app/[locale]/about/_components/CredentialList/index.tsx
+++ b/src/app/[locale]/about/_components/CredentialList/index.tsx
@@ -1,0 +1,56 @@
+import { pickLocalized } from "@/lib/i18n-utils";
+import { CREDENTIALS, CREDENTIALS_NOTE } from "@/static/about";
+import SectionHeading from "../SectionHeading";
+
+type CredentialListProps = {
+  locale: string;
+};
+
+// 保有資格セクション
+const CredentialList = ({ locale }: CredentialListProps) => {
+  const title = locale === "en" ? "Credentials" : "保有資格";
+  const externalAriaLabel = locale === "en" ? "Opens in new tab" : "新しいタブで開きます";
+
+  return (
+    <section aria-labelledby="credentials-heading">
+      <SectionHeading id="credentials-heading" eyebrow="// Credentials" title={title} />
+      <ul className="mt-8 grid gap-3 sm:grid-cols-2">
+        {CREDENTIALS.map((c) => {
+          const inner = (
+            <>
+              <span aria-hidden className="text-primary dark:text-base-color">🏅</span>
+              <div>
+                <p className="text-sm font-semibold leading-snug">{pickLocalized(c.title, locale)}</p>
+                <p className="mt-1 font-mono text-xs text-gray-500">{c.acquiredAt}</p>
+              </div>
+            </>
+          );
+          return (
+            <li key={c.id}>
+              {c.url ? (
+                <a
+                  href={c.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`${pickLocalized(c.title, locale)}（${externalAriaLabel}）`}
+                  className="flex items-start gap-3 rounded border border-gray-200 p-4 transition-colors duration-200 hover:border-base-color dark:border-gray-700 dark:hover:border-primary"
+                >
+                  {inner}
+                </a>
+              ) : (
+                <div className="flex items-start gap-3 rounded border border-gray-200 p-4 dark:border-gray-700">
+                  {inner}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      <p className="mt-6 max-w-prose text-sm italic text-gray-600 dark:text-gray-400">
+        {pickLocalized(CREDENTIALS_NOTE, locale)}
+      </p>
+    </section>
+  );
+};
+
+export default CredentialList;

--- a/src/app/[locale]/about/_components/HeroSection/index.tsx
+++ b/src/app/[locale]/about/_components/HeroSection/index.tsx
@@ -1,0 +1,95 @@
+import { MapPin } from "lucide-react";
+import SocialMediaIcons from "@/components/Header/SocialMediaIcons";
+import Chip from "@/components/UiParts/Chip";
+import ImageWithBlur from "@/components/UiParts/ImageWithBlur";
+import { pickLocalized } from "@/lib/i18n-utils";
+import { HERO_PROFILE } from "@/static/about";
+
+type HeroSectionProps = {
+  locale: string;
+};
+
+// ヒーローセクション。3秒で「何屋か」を伝えるパート
+const HeroSection = ({ locale }: HeroSectionProps) => {
+  const nameAlt = pickLocalized(HERO_PROFILE.nameAlt, locale);
+  const catchphrase = pickLocalized(HERO_PROFILE.catchphrase, locale);
+  const subText = pickLocalized(HERO_PROFILE.subText, locale);
+
+  return (
+    <section aria-labelledby="hero-heading" className="space-y-6">
+      {/* モバイル: 画像と名前を横並び。md+ では下部の hidden md:grid 側を見せる */}
+      <div className="flex items-start gap-4 md:hidden">
+        <ImageWithBlur
+          src="/author.png"
+          alt={`${nameAlt} のプロフィール写真`}
+          width={96}
+          height={96}
+          className="aspect-square w-20 shrink-0 rounded-full object-cover shadow-md"
+          priority
+        />
+        <div>
+          <h1
+            id="hero-heading"
+            className="text-3xl font-bold leading-tight tracking-tight text-gray-900 dark:text-gray-100"
+          >
+            {nameAlt}
+          </h1>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {HERO_PROFILE.badges.map((b) => (
+              <Chip
+                key={b}
+                label={b}
+                noTruncate
+                classes="bg-base-color text-white px-2 py-0.5 text-[10px] font-mono min-w-0"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* PC: テキスト左／画像右の伝統的なレイアウト */}
+      <div className="hidden md:grid grid-cols-[1fr_auto] gap-12 items-center">
+        <div className="space-y-5">
+          <div className="flex flex-wrap gap-2">
+            {HERO_PROFILE.badges.map((b) => (
+              <Chip
+                key={b}
+                label={b}
+                noTruncate
+                classes="bg-base-color text-white px-3 py-1 text-xs font-mono min-w-0"
+              />
+            ))}
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold leading-tight tracking-tight text-gray-900 dark:text-gray-100">
+            {nameAlt}
+          </h1>
+        </div>
+        <figure>
+          <ImageWithBlur
+            src="/author.png"
+            alt={`${nameAlt} のプロフィール写真`}
+            width={280}
+            height={280}
+            className="aspect-square w-[200px] md:w-[280px] rounded-full object-cover shadow-2xl"
+            priority
+          />
+        </figure>
+      </div>
+
+      {/* キャッチコピー / サブテキスト / 所在地 / SNS（PCとモバイル共通） */}
+      <p className="text-lg md:text-xl text-primary dark:text-base-color font-medium leading-snug text-balance">
+        {catchphrase}
+      </p>
+      <p className="max-w-prose text-gray-700 dark:text-gray-300 leading-relaxed">
+        {subText}
+      </p>
+      <p className="flex items-center gap-1.5 text-sm text-gray-500">
+        <MapPin aria-hidden className="h-4 w-4 shrink-0" />
+        {HERO_PROFILE.location}
+      </p>
+      <SocialMediaIcons locale={locale} />
+    </section>
+  );
+};
+
+export default HeroSection;

--- a/src/app/[locale]/about/_components/MissionSection/index.tsx
+++ b/src/app/[locale]/about/_components/MissionSection/index.tsx
@@ -1,0 +1,44 @@
+import { pickLocalized } from "@/lib/i18n-utils";
+import { MISSION } from "@/static/about";
+import SectionHeading from "../SectionHeading";
+
+type MissionSectionProps = {
+  locale: string;
+};
+
+// ミッションセクション。価値観を明示するブランドの軸
+const MissionSection = ({ locale }: MissionSectionProps) => {
+  const headline = pickLocalized(MISSION.headline, locale);
+  const body = pickLocalized(MISSION.body, locale);
+  const principles = pickLocalized(MISSION.principles, locale);
+  const title = locale === "en" ? "Why I write" : "このブログを書く理由";
+
+  return (
+    <section
+      aria-labelledby="mission-heading"
+      className="rounded-lg border border-base-color/30 dark:border-primary/30 bg-light/20 dark:bg-primary/10 p-6 md:p-10"
+    >
+      <SectionHeading id="mission-heading" eyebrow="// Mission" title={title} />
+      <p className="mt-8 text-xl md:text-2xl font-bold text-primary dark:text-base-color leading-snug text-balance">
+        {headline}
+      </p>
+      <div className="mt-6 space-y-4 max-w-prose text-gray-700 dark:text-gray-200 leading-relaxed">
+        {body.map((p, i) => (
+          <p key={i} dangerouslySetInnerHTML={{ __html: p }} />
+        ))}
+      </div>
+      <ul className="mt-8 grid gap-3 sm:grid-cols-2">
+        {principles.map((p) => (
+          <li key={p} className="flex gap-2 text-sm leading-relaxed">
+            <span aria-hidden className="shrink-0 font-mono text-primary dark:text-base-color">
+              ›
+            </span>
+            <span>{p}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default MissionSection;

--- a/src/app/[locale]/about/_components/NowSection/index.tsx
+++ b/src/app/[locale]/about/_components/NowSection/index.tsx
@@ -1,0 +1,42 @@
+import { pickLocalized } from "@/lib/i18n-utils";
+import { NOW } from "@/static/about";
+import SectionHeading from "../SectionHeading";
+
+type NowSectionProps = {
+  locale: string;
+};
+
+// /now ページ規範のセクション
+const NowSection = ({ locale }: NowSectionProps) => {
+  const title = locale === "en" ? "What I'm focused on now" : "いま取り組んでいること";
+  const lastUpdatedLabel = locale === "en" ? "Last updated" : "最終更新";
+
+  return (
+    <section
+      aria-labelledby="now-heading"
+      className="rounded-lg border border-base-color/30 dark:border-primary/30 bg-light/20 dark:bg-primary/10 p-6 md:p-10"
+    >
+      <SectionHeading id="now-heading" eyebrow="// /now" title={title} />
+      <p className="mt-8 max-w-prose text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+        {pickLocalized(NOW.intro, locale)}
+      </p>
+      <dl className="mt-6 grid gap-5 sm:grid-cols-2">
+        {NOW.items.map((item) => (
+          <div key={pickLocalized(item.category, locale)} className="flex flex-col gap-1.5">
+            <dt className="font-mono text-sm font-semibold text-primary dark:text-base-color">
+              {pickLocalized(item.category, locale)}
+            </dt>
+            <dd className="text-gray-700 dark:text-gray-300 leading-relaxed">
+              {pickLocalized(item.body, locale)}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      <p className="mt-6 font-mono text-xs text-gray-500">
+        {lastUpdatedLabel}: <time dateTime={NOW.lastUpdated}>{NOW.lastUpdated}</time>
+      </p>
+    </section>
+  );
+};
+
+export default NowSection;

--- a/src/app/[locale]/about/_components/OutputList/index.tsx
+++ b/src/app/[locale]/about/_components/OutputList/index.tsx
@@ -1,0 +1,63 @@
+import Chip from "@/components/UiParts/Chip";
+import { outputKindLabel, pickLocalized } from "@/lib/i18n-utils";
+import { OUTPUTS } from "@/static/about";
+import type { OutputKind } from "@/types/about";
+import { cltw } from "@/util";
+import SectionHeading from "../SectionHeading";
+
+type OutputListProps = {
+  locale: string;
+};
+
+// 種別ごとのバッジ色（執筆/登壇/選抜/主催）
+const kindBadgeClasses = (kind: OutputKind) =>
+  cltw(
+    "px-2 py-0.5 text-[11px] font-mono shrink-0 mt-0.5 min-w-0",
+    kind === "writing" && "bg-base-color/30 text-primary dark:bg-primary/30 dark:text-base-color",
+    kind === "speaking" && "bg-secondary/20 text-secondary",
+    kind === "selection" && "bg-light/50 text-txt-base dark:bg-light/20 dark:text-light",
+    kind === "organize" && "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  );
+
+// 登壇・執筆・選抜・主催の一覧
+const OutputList = ({ locale }: OutputListProps) => {
+  const title = locale === "en" ? "Talks, writing, selections" : "登壇・執筆・選抜";
+
+  return (
+    <section aria-labelledby="outputs-heading">
+      <SectionHeading id="outputs-heading" eyebrow="// Outputs" title={title} />
+      <ul className="mt-8 space-y-4">
+        {OUTPUTS.map((o) => {
+          const titleText = pickLocalized(o.title, locale);
+          return (
+            <li key={o.id} className="flex items-start gap-3">
+              <Chip label={outputKindLabel(o.kind, locale)} noTruncate classes={kindBadgeClasses(o.kind)} />
+              <div className="min-w-0 flex-1">
+                <p className="font-mono text-xs text-gray-500">{o.date}</p>
+                {o.url ? (
+                  <a
+                    href={o.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="break-words font-medium text-primary underline-offset-4 hover:underline dark:text-base-color"
+                  >
+                    {titleText}
+                  </a>
+                ) : (
+                  <p className="break-words font-medium">{titleText}</p>
+                )}
+                {o.summary && (
+                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                    {pickLocalized(o.summary, locale)}
+                  </p>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default OutputList;

--- a/src/app/[locale]/about/_components/PersonJsonLd/index.tsx
+++ b/src/app/[locale]/about/_components/PersonJsonLd/index.tsx
@@ -1,0 +1,47 @@
+import Script from "next/script";
+import type { Person, WithContext } from "schema-dts";
+import { baseURL } from "@/config";
+import { AUTHOR_E_MAIL } from "@/static/blogs";
+
+type PersonJsonLdProps = {
+  locale: string;
+};
+
+// about ページ用の Person schema を <script type="application/ld+json"> で出力
+const PersonJsonLd = ({ locale }: PersonJsonLdProps) => {
+  const data: WithContext<Person> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "りょた",
+    alternateName: ["Ryota"],
+    url: `${baseURL}/${locale}/about`,
+    image: `${baseURL}/author.png`,
+    jobTitle: "Software Engineer",
+    email: `mailto:${AUTHOR_E_MAIL}`,
+    sameAs: [
+      "https://x.com/Ryo54388667",
+      "https://zenn.dev/ryota_09",
+      "https://github.com/ryota-09",
+    ],
+    knowsAbout: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "AWS",
+      "Terraform",
+      "Hono",
+      "Prisma",
+    ],
+  };
+
+  return (
+    <Script
+      id="about-person-json-ld"
+      type="application/ld+json"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+};
+
+export default PersonJsonLd;

--- a/src/app/[locale]/about/_components/ProjectShowcase/ProjectCard/index.tsx
+++ b/src/app/[locale]/about/_components/ProjectShowcase/ProjectCard/index.tsx
@@ -1,0 +1,67 @@
+import Chip from "@/components/UiParts/Chip";
+import { pickLocalized } from "@/lib/i18n-utils";
+import type { Project } from "@/types/about";
+
+type ProjectCardProps = {
+  project: Project;
+  locale: string;
+};
+
+// プロジェクトカード（1件）
+const ProjectCard = ({ project, locale }: ProjectCardProps) => {
+  const title = pickLocalized(project.title, locale);
+  const period = pickLocalized(project.period, locale);
+  const role = pickLocalized(project.role, locale);
+  const scale = pickLocalized(project.scale, locale);
+  const rationale = pickLocalized(project.rationale, locale);
+
+  const labels = {
+    scale: locale === "en" ? "Scale" : "規模感",
+    rationale: locale === "en" ? "Tech choices" : "技術選定理由",
+  };
+
+  return (
+    <article className="flex h-full flex-col rounded border border-gray-200 bg-white p-5 transition-transform duration-200 hover:-translate-y-1 hover:border-base-color hover:shadow-lg dark:border-gray-700 dark:bg-black dark:hover:border-primary">
+      <p className="font-mono text-xs text-gray-500">{period}</p>
+      <h3 className="mt-2 text-base font-bold leading-snug">{title}</h3>
+      <p className="mt-2 text-sm font-medium text-primary dark:text-base-color">{role}</p>
+
+      <details className="mt-4">
+        <summary className="inline-flex cursor-pointer items-center gap-1 text-sm font-semibold hover:text-primary dark:hover:text-base-color">
+          <span aria-hidden className="transition-transform duration-200">›</span>
+          {labels.scale}
+        </summary>
+        <ul className="mt-2 space-y-1 pl-4 text-sm text-gray-600 dark:text-gray-400">
+          {scale.map((s) => (
+            <li key={s}>・{s}</li>
+          ))}
+        </ul>
+      </details>
+
+      <details className="mt-2">
+        <summary className="inline-flex cursor-pointer items-center gap-1 text-sm font-semibold hover:text-primary dark:hover:text-base-color">
+          <span aria-hidden className="transition-transform duration-200">›</span>
+          {labels.rationale}
+        </summary>
+        <ul className="mt-2 space-y-1 pl-4 text-sm text-gray-600 dark:text-gray-400">
+          {rationale.map((r) => (
+            <li key={r}>・{r}</li>
+          ))}
+        </ul>
+      </details>
+
+      <div className="mt-auto flex flex-wrap gap-1 pt-4">
+        {project.stack.map((t) => (
+          <Chip
+            key={t}
+            label={t}
+            noTruncate
+            classes="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 text-[10px] font-mono min-w-0"
+          />
+        ))}
+      </div>
+    </article>
+  );
+};
+
+export default ProjectCard;

--- a/src/app/[locale]/about/_components/ProjectShowcase/index.tsx
+++ b/src/app/[locale]/about/_components/ProjectShowcase/index.tsx
@@ -1,0 +1,40 @@
+import { pickLocalized } from "@/lib/i18n-utils";
+import { OTHER_PROJECTS, PROJECTS } from "@/static/about";
+import SectionHeading from "../SectionHeading";
+import ProjectCard from "./ProjectCard";
+
+type ProjectShowcaseProps = {
+  locale: string;
+};
+
+// 主な実績（3カード）＋ そのほかの実績（details で折りたたみ）
+const ProjectShowcase = ({ locale }: ProjectShowcaseProps) => {
+  const title = locale === "en" ? "Selected projects" : "主な実績";
+  const othersLabel = locale === "en" ? "Show other engagements" : "そのほかの実績を見る";
+
+  return (
+    <section aria-labelledby="projects-heading">
+      <SectionHeading id="projects-heading" eyebrow="// Projects" title={title} />
+      <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {PROJECTS.map((p) => (
+          <ProjectCard key={p.id} project={p} locale={locale} />
+        ))}
+      </div>
+      <details className="group mt-8">
+        <summary className="inline-flex cursor-pointer items-center gap-1 text-sm font-medium text-primary dark:text-base-color hover:underline underline-offset-4">
+          {othersLabel}
+          <span aria-hidden className="transition-transform duration-200 group-open:rotate-90">›</span>
+        </summary>
+        <ul className="mt-4 max-w-prose space-y-3 text-sm text-gray-700 dark:text-gray-300">
+          {OTHER_PROJECTS.map((o) => (
+            <li key={o.id}>
+              <strong>{pickLocalized(o.title, locale)}</strong> — {pickLocalized(o.summary, locale)}
+            </li>
+          ))}
+        </ul>
+      </details>
+    </section>
+  );
+};
+
+export default ProjectShowcase;

--- a/src/app/[locale]/about/_components/SectionHeading/index.stories.tsx
+++ b/src/app/[locale]/about/_components/SectionHeading/index.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import SectionHeading from ".";
+
+const meta = {
+  title: "About/SectionHeading",
+  component: SectionHeading,
+  tags: ["autodocs"],
+} satisfies Meta<typeof SectionHeading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    id: "story-heading",
+    eyebrow: "// Career",
+    title: "これまでの歩み",
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    id: "story-heading-desc",
+    eyebrow: "// Mission",
+    title: "このブログを書く理由",
+    description:
+      "同じ場所で詰まった人の時間を、5分でも短くする。を合言葉に書いています。",
+  },
+};
+
+export const NoEyebrow: Story = {
+  args: {
+    id: "story-heading-no-eyebrow",
+    title: "自己紹介",
+  },
+};

--- a/src/app/[locale]/about/_components/SectionHeading/index.tsx
+++ b/src/app/[locale]/about/_components/SectionHeading/index.tsx
@@ -1,0 +1,32 @@
+// 全 about セクション共通の見出し
+// eyebrow（コメント風小ラベル）＋ h2 タイトル ＋ 装飾線
+
+type SectionHeadingProps = {
+  id: string;
+  eyebrow?: string;
+  title: string;
+  description?: string;
+};
+
+const SectionHeading = ({ id, eyebrow, title, description }: SectionHeadingProps) => {
+  return (
+    <header>
+      {eyebrow && (
+        <p className="text-xs uppercase tracking-[0.2em] text-primary dark:text-base-color font-mono">
+          {eyebrow}
+        </p>
+      )}
+      <h2 id={id} className="mt-1 text-xl md:text-2xl font-bold text-gray-900 dark:text-gray-100 leading-snug">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed max-w-prose">
+          {description}
+        </p>
+      )}
+      <span aria-hidden className="mt-3 block w-12 h-0.5 bg-base-color dark:bg-primary" />
+    </header>
+  );
+};
+
+export default SectionHeading;

--- a/src/app/[locale]/about/_components/SkillStack/SkillGroup/index.tsx
+++ b/src/app/[locale]/about/_components/SkillStack/SkillGroup/index.tsx
@@ -1,0 +1,49 @@
+import Chip from "@/components/UiParts/Chip";
+import { pickLocalized } from "@/lib/i18n-utils";
+import type { SkillGroup as SkillGroupType, SkillLevel } from "@/types/about";
+import { cltw } from "@/util";
+
+type SkillGroupProps = {
+  level: SkillLevel;
+  groups: SkillGroupType[];
+  label: string;
+  locale: string;
+};
+
+// レベル別タグの見た目を返す（main / sub / learning で視覚差をつける）
+const tagClasses = (level: SkillLevel) =>
+  cltw(
+    "px-2.5 py-1 text-sm min-w-0",
+    level === "main" &&
+      "bg-base-color/20 text-txt-base dark:bg-primary/30 dark:text-gray-100 font-medium",
+    level === "sub" && "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    level === "learning" &&
+      "opacity-80 border border-dashed border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400",
+  );
+
+// スキルグループ（レベル1個ぶん）
+const SkillGroup = ({ level, groups, label, locale }: SkillGroupProps) => {
+  return (
+    <div>
+      <h3 className="mb-3 font-mono text-sm uppercase tracking-widest text-gray-500">
+        {label}
+      </h3>
+      <div className="space-y-3">
+        {groups.map((g) => (
+          <div key={pickLocalized(g.category, locale)}>
+            <p className="mb-1.5 text-xs font-medium text-gray-500">
+              {pickLocalized(g.category, locale)}
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {g.items.map((item) => (
+                <Chip key={item} label={item} noTruncate classes={tagClasses(level)} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SkillGroup;

--- a/src/app/[locale]/about/_components/SkillStack/index.tsx
+++ b/src/app/[locale]/about/_components/SkillStack/index.tsx
@@ -1,0 +1,32 @@
+import { SKILL_GROUPS } from "@/static/about";
+import SectionHeading from "../SectionHeading";
+import SkillGroup from "./SkillGroup";
+
+type SkillStackProps = {
+  locale: string;
+};
+
+// スキルスタックセクション
+const SkillStack = ({ locale }: SkillStackProps) => {
+  const mainGroups = SKILL_GROUPS.filter((g) => g.level === "main");
+  const subGroups = SKILL_GROUPS.filter((g) => g.level === "sub");
+
+  const labels = {
+    main: locale === "en" ? "Primary in work" : "業務でメイン",
+    sub: locale === "en" ? "Secondary" : "業務でサブ",
+  };
+  const title = locale === "en" ? "Tech stack" : "技術スタック";
+
+  return (
+    <section aria-labelledby="skills-heading">
+      <SectionHeading id="skills-heading" eyebrow="// Skills" title={title} />
+
+      <div className="mt-8 space-y-8">
+        <SkillGroup level="main" groups={mainGroups} label={labels.main} locale={locale} />
+        <SkillGroup level="sub" groups={subGroups} label={labels.sub} locale={locale} />
+      </div>
+    </section>
+  );
+};
+
+export default SkillStack;

--- a/src/app/[locale]/about/layout.tsx
+++ b/src/app/[locale]/about/layout.tsx
@@ -6,19 +6,37 @@ import { baseURL } from "@/config";
 
 interface AboutLayoutProps {
   children: React.ReactNode;
-  params: {
+  params: Promise<{
     locale: string;
-  };
+  }>;
 }
 
-export async function generateMetadata({ params: { locale } }: AboutLayoutProps): Promise<Metadata> {
-  const t = await getTranslations({ locale, namespace: 'metadata' });
-  const tNav = await getTranslations({ locale, namespace: 'navigation' });
-  
+export async function generateMetadata({ params }: AboutLayoutProps): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'about' });
+
   return {
-    title: tNav('about'),
-    description: t('siteDescription'),
-    metadataBase: new URL(baseURL)
+    title: t('pageTitle'),
+    description: t('pageDescription'),
+    metadataBase: new URL(baseURL),
+    alternates: {
+      canonical: `${baseURL}/${locale}/about`,
+      languages: {
+        ja: `${baseURL}/ja/about`,
+        en: `${baseURL}/en/about`,
+      },
+    },
+    openGraph: {
+      url: `${baseURL}/${locale}/about`,
+      title: t('pageTitle'),
+      description: t('pageDescription'),
+      images: [{ url: `${baseURL}/og-image.png`, width: 1200, height: 630 }],
+      type: 'profile',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      images: [`${baseURL}/og-image.png`],
+    },
   };
 }
 

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,7 +1,10 @@
-import SocialMediaIcons from "@/components/Header/SocialMediaIcons";
-import Chip from "@/components/UiParts/Chip";
-import ImageWithBlur from "@/components/UiParts/ImageWithBlur";
-import { AUTHOR_DESCRIPTION, AUTHOR_DESCRIPTION_EN, AUTHOR_NAME, AUTHOR_NAME_EN } from "@/static/blogs";
+import AboutMeSection from "./_components/AboutMeSection";
+import CareerTimeline from "./_components/CareerTimeline";
+import ContactSection from "./_components/ContactSection";
+import HeroSection from "./_components/HeroSection";
+import MissionSection from "./_components/MissionSection";
+import PersonJsonLd from "./_components/PersonJsonLd";
+import SkillStack from "./_components/SkillStack";
 
 interface AboutPageProps {
   params: Promise<{
@@ -9,37 +12,21 @@ interface AboutPageProps {
   }>;
 }
 
+// aboutページ。10セクションを縦に並べる
 const Page = async ({ params }: AboutPageProps) => {
-  // Next.js 16では、paramsを非同期で取得する必要がある
   const { locale } = await params;
-  const authorName = locale === 'en' ? AUTHOR_NAME_EN : AUTHOR_NAME;
-  const authorDescription = locale === 'en' ? AUTHOR_DESCRIPTION_EN : AUTHOR_DESCRIPTION;
-  
+
   return (
-    <article className="flex h-full min-h-[600px] w-full flex-grow flex-col items-center justify-center gap-8 border-2 border-gray-200 bg-white px-8 md:flex-row md:justify-between dark:border-gray-600 dark:bg-black">
-      <div className="flex flex-col items-start space-y-8">
-        <Chip
-          label={"Software Engineer"}
-          classes="bg-light dark:bg-primary py-1 px-3 text-txt-base"
-        />
-        <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl md:text-6xl dark:text-gray-300">
-          {authorName}
-        </h1>
-        <p className="max-w-[600px] text-gray-500 md:text-xl/relaxed lg:text-base/relaxed xl:text-xl/relaxed dark:text-gray-400">
-          {authorDescription}
-        </p>
-        <SocialMediaIcons locale={locale} />
-      </div>
-      <figure>
-        <ImageWithBlur
-          src="/author.png"
-          alt={authorName}
-          className="mx-auto block aspect-square w-[200px] overflow-hidden rounded-full object-cover shadow-2xl md:w-[400px]"
-          width={400}
-          height={400}
-        />
-      </figure>
+    <article className="mx-auto w-full max-w-4xl animate-fadeIn flex-grow space-y-16 bg-white px-4 py-12 sm:px-6 md:space-y-24 md:py-16 lg:px-8 dark:bg-black">
+      <HeroSection locale={locale} />
+      <AboutMeSection locale={locale} />
+      <MissionSection locale={locale} />
+      <CareerTimeline locale={locale} />
+      <SkillStack locale={locale} />
+      <ContactSection locale={locale} />
+      <PersonJsonLd locale={locale} />
     </article>
   );
 };
+
 export default Page;

--- a/src/components/UiParts/Chip/index.stories.tsx
+++ b/src/components/UiParts/Chip/index.stories.tsx
@@ -16,3 +16,18 @@ export const Default: Story = {
     classes: 'bg-secondary text-white w-12',
   }
 }
+
+export const WithLongLabel: Story = {
+  args: {
+    label: 'これは長いラベルのテストケースです',
+    classes: 'bg-secondary text-white px-3',
+  }
+}
+
+export const NoTruncate: Story = {
+  args: {
+    label: 'GitHub Actions / Terraform / Playwright',
+    classes: 'bg-base-color text-white px-3',
+    noTruncate: true,
+  }
+}

--- a/src/components/UiParts/Chip/index.tsx
+++ b/src/components/UiParts/Chip/index.tsx
@@ -5,11 +5,17 @@ const MAX_LENGTH = 20;
 type ChipProps = {
   label: string;
   classes?: string;
+  // 20文字超のラベルでも省略せずに表示する場合は true
+  noTruncate?: boolean;
 }
 
-const Chip = ({ label, classes = "" }: ChipProps) => {
+const Chip = ({ label, classes = "", noTruncate = false }: ChipProps) => {
+  // noTruncate なら常に元のラベル、それ以外は20文字超で省略
+  const displayLabel = noTruncate || label.length < MAX_LENGTH
+    ? label
+    : label.slice(0, MAX_LENGTH) + "...";
   return (
-    <p className={cltw("rounded-full min-w-20 text-center", classes)}>{label.length < MAX_LENGTH ? label : label.slice(0, MAX_LENGTH) + "..."}</p>
+    <p className={cltw("rounded-full min-w-20 text-center", classes)}>{displayLabel}</p>
   )
 }
 export default Chip;

--- a/src/lib/i18n-utils.ts
+++ b/src/lib/i18n-utils.ts
@@ -89,3 +89,57 @@ export function getLocalizedCategoryName(category: CategoriesContentType, locale
   // それ以外は日本語名を使用
   return category.name;
 }
+
+/**
+ * 多言語データから現在のロケールに合致する値を取り出す
+ */
+export const pickLocalized = <T,>(value: { ja: T; en: T }, locale: string): T =>
+  locale === "en" ? value.en : value.ja;
+
+/**
+ * "YYYY-MM" を年月の表示用に整形する
+ */
+const formatYearMonth = (yyyyMm: string, locale: string): string => {
+  const [yearStr, monthStr] = yyyyMm.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  if (locale === "en") {
+    const monthsEn = [
+      "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    return `${monthsEn[month - 1]} ${year}`;
+  }
+  return `${year}年${month}月`;
+};
+
+/**
+ * キャリアタイムラインの期間表示文字列
+ */
+export const formatPeriod = (
+  period: { start: string; end: string | null },
+  locale: string,
+): string => {
+  const start = formatYearMonth(period.start, locale);
+  if (period.end === null) {
+    return locale === "en" ? `${start} — Present` : `${start} 〜 現在`;
+  }
+  const end = formatYearMonth(period.end, locale);
+  return locale === "en" ? `${start} — ${end}` : `${start} 〜 ${end}`;
+};
+
+/**
+ * OutputEntry の種別ラベル（執筆/登壇/選抜/主催）
+ */
+export const outputKindLabel = (
+  kind: "writing" | "speaking" | "selection" | "organize",
+  locale: string,
+): string => {
+  const labelMap = {
+    writing: { ja: "執筆", en: "Writing" },
+    speaking: { ja: "登壇", en: "Speaking" },
+    selection: { ja: "選抜", en: "Selection" },
+    organize: { ja: "主催", en: "Organize" },
+  };
+  return pickLocalized(labelMap[kind], locale);
+};

--- a/src/static/about/contact.ts
+++ b/src/static/about/contact.ts
@@ -1,0 +1,51 @@
+import { AUTHOR_E_MAIL } from "@/static/blogs";
+import type { Contact } from "@/types/about";
+
+// 連絡先と相談ジャンル
+export const CONTACT: Contact = {
+  intro: {
+    ja: [
+      "業務委託・スポット相談・技術アドバイザリのご相談を歓迎しています。フルタイム転職のオファーは、現職の比較対象として強くマッチする内容であれば検討します。",
+    ],
+    en: [
+      "I'm open to contract work, spot consultations, and technical advisory. Full-time offers are evaluated against my current role.",
+    ],
+  },
+  acceptedTopics: {
+    ja: [
+      "ソフトウェア開発、完全初期段階の MVP 受託",
+      "AWS / Terraform を組み合わせた小〜中規模インフラの構築相談",
+      "採用や育成（オンボーディング設計など）の相談",
+    ],
+    en: [
+      "Software development, including early-stage MVP builds",
+      "Small-to-mid AWS infrastructure work with Terraform",
+      "Hiring and onboarding design",
+    ],
+  },
+  declinedTopics: {
+    ja: ["長期常駐案件"],
+    en: ["Long-term on-site embedded engagements"],
+  },
+  channels: [
+    {
+      kind: "email",
+      label: { ja: "Email", en: "Email" },
+      href: `mailto:${AUTHOR_E_MAIL}`,
+    },
+    {
+      kind: "form",
+      label: { ja: "お問い合わせフォーム", en: "Contact form" },
+      href: "https://docs.google.com/forms/d/1RP2EUWjYvEa2gwFd0bjFurmZxUFCfvxtwxqpm6ggO68/viewform",
+    },
+    {
+      kind: "social",
+      label: { ja: "X (Twitter) DM", en: "X (Twitter) DM" },
+      href: "https://x.com/Ryo54388667",
+    },
+  ],
+  responseSla: {
+    ja: "3営業日以内に一次返信を目指しています。",
+    en: "Aiming to send a first reply within three business days.",
+  },
+};

--- a/src/static/about/credentials.ts
+++ b/src/static/about/credentials.ts
@@ -1,0 +1,46 @@
+import type { Credential, LocalizedText } from "@/types/about";
+
+// 保有資格
+export const CREDENTIALS: Credential[] = [
+  {
+    id: "aws-sysops-associate",
+    title: {
+      ja: "AWS Certified SysOps Administrator – Associate",
+      en: "AWS Certified SysOps Administrator – Associate",
+    },
+    acquiredAt: "2023-06",
+    url: "https://aws.amazon.com/jp/certification/certified-sysops-admin-associate/",
+  },
+  {
+    id: "aws-developer-associate",
+    title: {
+      ja: "AWS Certified Developer – Associate",
+      en: "AWS Certified Developer – Associate",
+    },
+    acquiredAt: "2023-02",
+    url: "https://aws.amazon.com/jp/certification/certified-developer-associate/",
+  },
+  {
+    id: "aws-saa-associate",
+    title: {
+      ja: "AWS Certified Solutions Architect – Associate",
+      en: "AWS Certified Solutions Architect – Associate",
+    },
+    acquiredAt: "2023-02",
+    url: "https://aws.amazon.com/jp/certification/certified-solutions-architect-associate/",
+  },
+  {
+    id: "math-teacher-license",
+    title: {
+      ja: "高等学校教諭一種免許状（数学）",
+      en: "High School Teacher Class-I License (Mathematics, Japan)",
+    },
+    acquiredAt: "2018-03",
+  },
+];
+
+// 意味付けの一言（資格セクションの下部に小さく出す）
+export const CREDENTIALS_NOTE: LocalizedText = {
+  ja: "フロントエンド出身者で AWS 3資格を保有しているケースは多くなく、Terraform で IaC を書くベースになっています。",
+  en: "Coming from a frontend background, holding the three AWS Associates is uncommon — it underpins how I write Terraform-managed infrastructure.",
+};

--- a/src/static/about/index.ts
+++ b/src/static/about/index.ts
@@ -1,0 +1,10 @@
+// aboutページで使う静的データの集約 re-export
+
+export { ABOUT_ME, HERO_PROFILE, MISSION } from "./profile";
+export { TIMELINE } from "./timeline";
+export { SKILL_GROUPS, STRENGTHS } from "./skills";
+export { OTHER_PROJECTS, PROJECTS } from "./projects";
+export { CREDENTIALS, CREDENTIALS_NOTE } from "./credentials";
+export { OUTPUTS } from "./outputs";
+export { NOW } from "./now";
+export { CONTACT } from "./contact";

--- a/src/static/about/now.ts
+++ b/src/static/about/now.ts
@@ -1,0 +1,48 @@
+import type { Now } from "@/types/about";
+
+// /now ページ規範に沿った「いま取り組んでいること」
+export const NOW: Now = {
+  intro: {
+    ja: "このセクションは私の \"now\" です。直近で意識的に時間を割いていることを書いています。",
+    en: "This is my \"now.\" Things I'm actively spending time on right now.",
+  },
+  items: [
+    {
+      category: { ja: "業務", en: "Work" },
+      body: {
+        ja:
+          "Next.js 16 の Cache Components を実プロダクトに導入するためのパフォーマンス検証。App Router の use cache ディレクティブと既存 ISR 構成の併存パターンを試行中。",
+        en:
+          "Validating Next.js 16 Cache Components for production use — figuring out how the `use cache` directive coexists with existing ISR setups.",
+      },
+    },
+    {
+      category: { ja: "学習", en: "Learning" },
+      body: {
+        ja:
+          "Hono と Prisma を主軸にしたバックエンド設計を、社内のいろんなチームに刺さる粒度で言語化中。",
+        en:
+          "Putting into words how I design Hono + Prisma backends, at the granularity that lands with different internal teams.",
+      },
+    },
+    {
+      category: { ja: "このブログ", en: "This blog" },
+      body: {
+        ja:
+          "SEO とパフォーマンスを改善する小さな実験を、不定期で走らせています（直近: View Transitions API のページ間遷移、画像配信の最適化）。",
+        en:
+          "Running small experiments on SEO and performance (recently: View Transitions for page changes, image delivery tuning).",
+      },
+    },
+    {
+      category: { ja: "AI", en: "AI" },
+      body: {
+        ja:
+          "生成 AI を「コードを書く時間を短くする」のではなく「コードを書く前のリサーチ・設計を厚くする」方向で開発フローに組み込む試行。",
+        en:
+          "Folding generative AI into my workflow — not to speed up coding, but to deepen the research and design that happens before the coding.",
+      },
+    },
+  ],
+  lastUpdated: "2026-05-22",
+};

--- a/src/static/about/outputs.ts
+++ b/src/static/about/outputs.ts
@@ -1,0 +1,51 @@
+import type { OutputEntry } from "@/types/about";
+
+// 登壇・執筆・選抜・主催の実績
+export const OUTPUTS: OutputEntry[] = [
+  {
+    id: "zenn-articles",
+    kind: "writing",
+    title: {
+      ja: "Zenn でフロントエンド・クラウド関連記事を継続執筆中",
+      en: "Continuous writing about frontend and cloud topics on Zenn",
+    },
+    date: "2022 〜",
+    url: "https://zenn.dev/ryota_09",
+  },
+  {
+    id: "ryota-blog-articles",
+    kind: "writing",
+    title: {
+      ja: "このブログ（Ryota-Blog）で業務知見を発信中",
+      en: "Sharing work knowledge on this blog (Ryota-Blog)",
+    },
+    date: "2024 〜",
+  },
+  {
+    id: "devcan-2",
+    kind: "selection",
+    title: {
+      ja: "DevCan#2 hosted by Classmethod に募集枠8名で選抜",
+      en: "Selected to DevCan #2 (8-person cohort) hosted by Classmethod",
+    },
+    date: "2024",
+    url: "https://zenn.dev/devcamp/articles/6584f40e67da80",
+    summary: {
+      ja: "AWS 環境の構築・構成図・提案書を一貫制作。",
+      en: "Built AWS environments, diagrams, and proposals end-to-end.",
+    },
+  },
+  {
+    id: "internal-lt-2023",
+    kind: "organize",
+    title: {
+      ja: "社内 LT 大会の主催（オフライン・参加者30〜40名）",
+      en: "Organized an in-house lightning talk meetup (offline, 30–40 attendees)",
+    },
+    date: "2023-07",
+    summary: {
+      ja: "司会進行と登壇者募集（3名）を担当。",
+      en: "Hosting and speaker recruitment (3 speakers).",
+    },
+  },
+];

--- a/src/static/about/profile.ts
+++ b/src/static/about/profile.ts
@@ -1,0 +1,69 @@
+import type { AboutMeBody, HeroProfile, Mission } from "@/types/about";
+
+// ヒーローセクション
+export const HERO_PROFILE: HeroProfile = {
+  name: "りょた",
+  nameAlt: { ja: "りょた", en: "Ryota" },
+  badges: ["Software Engineer"],
+  catchphrase: {
+    ja: "泥臭いことをバカにせず。",
+    en: "Honor the grunt work.",
+  },
+  subText: {
+    ja:
+      "東京の物流スタートアップで、Next.js / TypeScript / AWS を扱うフルスタックエンジニア。フロントエンドが軸足、Terraform でインフラまで書きます。教育業界 → SES業界 → 物流業界と、3つの現場を渡ってきました。",
+    en:
+      "Software engineer at a Tokyo-based logistics startup, working across Next.js, TypeScript, and AWS. Frontend-centric, infrastructure-aware. I've worked across three industries — education, contract engineering, and logistics.",
+  },
+  location: "Tokyo, Japan",
+};
+
+// 自己紹介本文（.highlight クラスで強調可能）
+export const ABOUT_ME: AboutMeBody = {
+  paragraphs: {
+    ja: [
+      "はじめまして、<span class=\"highlight\">りょた</span>です。東京の物流スタートアップで、Web メディア、SaaS、官公庁向け情報ポータルの開発を担当しています。フロントエンドが軸足ですが、Terraform で AWS インフラを書き、Hono と Prisma で API を組み、CI/CD パイプラインまで一人で設計・構築するところまで含めて担当範囲です。",
+      "もともとは、地方の公立中学校で <span class=\"highlight\">数学を教える教員</span>をしていました。3年間、毎日「どの順番で説明すれば一番伝わるか」を考えていた経験は、いまもコードレビュー、ドキュメント、API 設計、UI の情報設計と、職場のあらゆる場面で生きています。",
+      "このブログは、その延長線上にあります。業務で詰まったポイントや、検証してわかった落とし穴を、「同じ場所で詰まった誰かが5分でも早く前に進めるように」と思って書いています。",
+    ],
+    en: [
+      "Hi, I'm <span class=\"highlight\">Ryota</span>. I'm a fullstack software engineer at a logistics startup in Tokyo, building web media, internal SaaS, and government information portals end to end — from the frontend in Next.js, through APIs in Hono and Prisma, to AWS infrastructure provisioned with Terraform.",
+      "Before becoming an engineer, I spent three years <span class=\"highlight\">teaching math</span> at a public middle school in a rural part of Japan. Thinking every day about how to explain something so it actually lands still shapes how I write code reviews, design APIs, and structure UI today.",
+      "On this blog, I write about the kind of problems that don't fit cleanly in a tutorial — the half-day debugging detours, the production-only failures, the migration paths nobody documented. The goal is simple: shave five minutes off the next person who gets stuck where I got stuck.",
+    ],
+  },
+  hobbies: {
+    ja: "オフは麻辣湯巡り、散歩、お酒を楽しんでいます。",
+    en: "Off the keyboard: hunting down mala tang shops, going for walks, and enjoying a good drink.",
+  },
+};
+
+// ミッションセクション
+export const MISSION: Mission = {
+  headline: {
+    ja: "同じ場所で詰まった人の時間を、5分でも短くする",
+    en: "Save five minutes for the next person stuck where I got stuck.",
+  },
+  body: {
+    ja: [
+      "Web 開発は、ドキュメントを読んでも一発で動かないことが多い。私自身、CORS の謎エラーで何時間も止まったり、Amplify と Next.js の組み合わせで本番だけ 503 を吐かれたり、何度もコードを書き直したりしてきました。",
+      "そのときに <span class=\"highlight\">「あ、ここで誰かの記事を読んでいたら助かったのに」</span>と思った瞬間を、自分の手で減らしたい。だからこのブログでは、抽象論や流行りの紹介ではなく、実際に手で動かして詰まった話と、その時どう抜けたかを中心に書いています。",
+    ],
+    en: [
+      "Web development rarely works on the first try, even when you've read the docs. I've spent hours stuck on cryptic CORS errors, only to find Amplify + Next.js was returning 503s in production, and rewritten the same code over and over.",
+      "In those moments, I always thought: <span class=\"highlight\">\"if only someone had written about this exact issue.\"</span> That's the gap I want to close. On this blog, you'll find hands-on lessons from real bugs — not trend reports or abstract advice.",
+    ],
+  },
+  principles: {
+    ja: [
+      "コードより先に、伝え方を考える（教員時代の癖）",
+      "「動いた」で終わらせず、「なぜ動いたか」まで残す",
+      "誰かの記事に助けられた分を、自分の記事で返す",
+    ],
+    en: [
+      "Think about how to explain it before writing the code (a habit from teaching).",
+      "Don't stop at \"it works\" — capture why it works.",
+      "Pay forward every article that ever helped me.",
+    ],
+  },
+};

--- a/src/static/about/projects.ts
+++ b/src/static/about/projects.ts
@@ -1,0 +1,170 @@
+import type { OtherProject, Project } from "@/types/about";
+
+// 主な実績（3カード）
+export const PROJECTS: Project[] = [
+  {
+    id: "gov-portal",
+    title: {
+      ja: "官公庁向け情報ポータルの本番構築",
+      en: "Government information portal — production launch",
+    },
+    period: {
+      ja: "2025年12月 〜 2026年2月",
+      en: "Dec 2025 — Feb 2026",
+    },
+    role: {
+      ja: "フルスタックエンジニア（設計〜実装〜インフラ〜DNS まで一貫）",
+      en: "Fullstack engineer (design through infrastructure and DNS)",
+    },
+    scale: {
+      ja: [
+        "go.jp ドメインの本番案件",
+        "Terraform 6モジュールで AWS インフラ全体を IaC 化",
+        "3層アーキテクチャ（Controller / Service / Repository）で13モデルのDB 設計",
+        "3段階 RBAC + 事業者スコープのマルチテナント管理画面",
+      ],
+      en: [
+        "Live behind a go.jp domain",
+        "AWS infra fully IaC-managed via six Terraform modules",
+        "13-model DB modeled with a three-layer Controller / Service / Repository architecture",
+        "Multi-tenant admin with three-level RBAC and per-operator scoping",
+      ],
+    },
+    rationale: {
+      ja: [
+        "Amplify を選んだ理由: 官公庁ドメイン接続の安全な切り替え経路と CDN を、最短で整備するため。",
+        "Hono を選んだ理由: 軽量・型安全・OpenAPI 自動生成を1スタックで完結させるため。",
+      ],
+      en: [
+        "Why Amplify: fastest safe path to switching a government domain over CDN.",
+        "Why Hono: lightweight, type-safe, and OpenAPI generation all in one stack.",
+      ],
+    },
+    stack: [
+      "Next.js 16",
+      "React 19",
+      "Hono",
+      "Prisma",
+      "MySQL",
+      "Terraform",
+      "AWS Amplify",
+      "AWS SES",
+      "GitHub Actions",
+      "Vitest",
+      "Playwright",
+    ],
+  },
+  {
+    id: "logistics-saas-media",
+    title: {
+      ja: "物流企業向け SaaS ＋ toC メディア",
+      en: "Logistics SaaS and consumer media",
+    },
+    period: {
+      ja: "2024年7月 〜 現在",
+      en: "Jul 2024 — Present",
+    },
+    role: {
+      ja: "フロントエンドリード／SEO 設計",
+      en: "Frontend lead and SEO architect",
+    },
+    scale: {
+      ja: [
+        "自社プロダクトの SaaS と toC 向けメディアサイトを並行運用",
+        "狙ったキーワードで Google 検索上位を獲得",
+        "ChatGPT Web 検索のソースとしてピックアップされる事例も確認",
+      ],
+      en: [
+        "Run SaaS and consumer-facing media in parallel",
+        "Hit top organic rankings for targeted keywords",
+        "Confirmed picks as a source in ChatGPT web search results",
+      ],
+    },
+    rationale: {
+      ja: [
+        "Next.js App Router を選んだ理由: ISR で SEO とパフォーマンスを両立しつつ、必要に応じて SSR に切り替えられる柔軟性のため。",
+        "独自 CMS 機能の最小実装を選んだ理由: 編集者の操作フローが既存 SaaS と合わず、要件に合わせて作り込んだ方が運用負荷が下がるため。",
+      ],
+      en: [
+        "Why Next.js App Router: ISR for SEO/perf balance, with SSR as a clean escape hatch.",
+        "Why we built a minimal in-house CMS: editor workflows didn't fit off-the-shelf SaaS — custom paid off in ops.",
+      ],
+    },
+    stack: ["Next.js", "TypeScript", "Tailwind CSS", "Core Web Vitals"],
+  },
+  {
+    id: "ai-chat-app",
+    title: {
+      ja: "生成 AI チャットアプリケーションの開発",
+      en: "Generative AI chat application",
+    },
+    period: {
+      ja: "2023年12月",
+      en: "Dec 2023",
+    },
+    role: {
+      ja: "フロントエンドエンジニア",
+      en: "Frontend engineer",
+    },
+    scale: {
+      ja: [
+        "数万件規模のデータを扱う SaaS",
+        "大規模データ表示のパフォーマンスを仮想ウィンドウで改善",
+        "ロール／ポリシー単位の RBAC をフロントから一貫実装",
+      ],
+      en: [
+        "SaaS handling tens of thousands of records",
+        "Virtualized rendering to keep large lists smooth",
+        "Role and policy-based RBAC implemented end-to-end on the client",
+      ],
+    },
+    rationale: {
+      ja: [
+        "仮想ウィンドウを採用した理由: ページネーションでは UX の連続性が失われるため、操作のスムーズさを優先。",
+        "RBAC をフロントで実装した範囲: バックエンドの権限管理に加え、UI 表示制御を独立して持ち、編集ミス時の影響範囲を最小化。",
+      ],
+      en: [
+        "Why virtualization, not pagination: continuity of interaction beats page jumps.",
+        "Frontend RBAC scope: in addition to server-side checks, we kept UI gating independent to limit blast radius.",
+      ],
+    },
+    stack: ["Next.js", "TypeScript", "Azure OpenAI"],
+  },
+];
+
+// その他実績（accordion で出す）
+export const OTHER_PROJECTS: OtherProject[] = [
+  {
+    id: "logistics-core-maintenance",
+    title: {
+      ja: "物流基幹システムの保守（1000社超利用）",
+      en: "Maintenance of a logistics core system (1000+ companies)",
+    },
+    summary: {
+      ja: "Oracle DB ストアドプロシージャ整備、5名チームでの安定運用と小規模改善。",
+      en: "Oracle DB stored procedure work, stable operation and small improvements within a five-person team.",
+    },
+  },
+  {
+    id: "studypocket-qa",
+    title: {
+      ja: "スタディポケット（教育系 AI スタートアップ）の QA エンジニア業務委託",
+      en: "QA engineer (contract) at StudyPocket, an EdTech AI startup",
+    },
+    summary: {
+      ja: "テスト計画、テスト仕様書、E2E テスト実装、ドキュメント整備を担当。",
+      en: "Test plans, test specs, E2E implementation, and documentation cleanup.",
+    },
+  },
+  {
+    id: "onboarding-design",
+    title: {
+      ja: "インターン1名・中途2名のオンボーディング設計",
+      en: "Onboarding design for 1 intern and 2 mid-career hires",
+    },
+    summary: {
+      ja: "受け入れ手順書・初週スケジュール・権限設定の標準化。",
+      en: "Standardized intake docs, week-one schedule, and access provisioning.",
+    },
+  },
+];

--- a/src/static/about/skills.ts
+++ b/src/static/about/skills.ts
@@ -1,0 +1,99 @@
+import type { SkillGroup, StrengthArea } from "@/types/about";
+
+// 技術スタック（3層に分けて表示）
+export const SKILL_GROUPS: SkillGroup[] = [
+  // メイン（業務でメイン）
+  {
+    level: "main",
+    category: { ja: "Languages", en: "Languages" },
+    items: ["TypeScript", "JavaScript"],
+  },
+  {
+    level: "main",
+    category: { ja: "Frontend", en: "Frontend" },
+    items: ["React 19", "Next.js (App Router)", "Tailwind CSS", "shadcn/ui"],
+  },
+  {
+    level: "main",
+    category: { ja: "Backend", en: "Backend" },
+    items: ["Hono", "Prisma ORM", "MySQL", "OpenAPI"],
+  },
+  {
+    level: "main",
+    category: { ja: "Infra", en: "Infra" },
+    items: ["AWS Amplify", "AWS S3", "AWS SES", "AWS ACM", "AWS Lambda", "Terraform", "GitHub Actions"],
+  },
+  {
+    level: "main",
+    category: { ja: "Testing", en: "Testing" },
+    items: ["Vitest", "Playwright", "Storybook", "TDD"],
+  },
+  // サブ（業務でサブ）
+  {
+    level: "sub",
+    category: { ja: "Backend (sub)", en: "Backend (sub)" },
+    items: ["Python", "FastAPI", "Azure OpenAI"],
+  },
+  {
+    level: "sub",
+    category: { ja: "DB / Auth", en: "DB / Auth" },
+    items: ["Oracle DB", "Firebase Authentication"],
+  },
+  {
+    level: "sub",
+    category: { ja: "CMS", en: "CMS" },
+    items: ["microCMS"],
+  },
+];
+
+// 得意としている領域（差別化軸）
+export const STRENGTHS: StrengthArea[] = [
+  {
+    title: {
+      ja: "Next.js × SEO × Core Web Vitals",
+      en: "Next.js × SEO × Core Web Vitals",
+    },
+    description: {
+      ja:
+        "ISR / SSR の使い分け、画像最適化、View Transitions API を組み合わせて、SEO とパフォーマンスを同時に最適化する設計が得意です。",
+      en:
+        "Tuning the trio together — ISR/SSR split, image optimization, and View Transitions — so SEO and performance move in the same direction.",
+    },
+  },
+  {
+    title: {
+      ja: "AWS を Terraform で IaC 化",
+      en: "AWS as Terraform-managed IaC",
+    },
+    description: {
+      ja:
+        "フロントエンド出身者でも読みやすい構成で、AWS インフラ全体を IaC 化します。Amplify / SES / ACM など実運用ノウハウ込み。",
+      en:
+        "I write Terraform that frontend devs can read. Production-grade Amplify, SES, ACM, and ACME knowledge included.",
+    },
+  },
+  {
+    title: {
+      ja: "フロント起点で API〜インフラまで一貫",
+      en: "Frontend-out, all the way to infra",
+    },
+    description: {
+      ja:
+        "UI の要件から API スキーマ・インフラ設計を一気通貫で組める動き方。ハンドオフが減って、開発全体が速くなります。",
+      en:
+        "Designing UI, API, and infrastructure as one continuous concern — fewer handoffs, faster delivery.",
+    },
+  },
+  {
+    title: {
+      ja: "「伝える」設計",
+      en: "Design for clarity",
+    },
+    description: {
+      ja:
+        "ドキュメント整備、オンボーディング、コードレビューでの言語化。教員時代から積み上げた『伝わる順序』の感覚を活かしています。",
+      en:
+        "Documentation, onboarding, code reviews — every place I can make information land. A habit carried over from teaching.",
+    },
+  },
+];

--- a/src/static/about/timeline.ts
+++ b/src/static/about/timeline.ts
@@ -1,0 +1,80 @@
+import type { TimelineEntry } from "@/types/about";
+
+// キャリアタイムライン（直近→過去の順）
+export const TIMELINE: TimelineEntry[] = [
+  {
+    id: "current-logistics-startup",
+    period: { start: "2024-07", end: null },
+    role: {
+      ja: "フルスタックエンジニア",
+      en: "Fullstack Engineer",
+    },
+    org: {
+      ja: "東京の物流スタートアップ",
+      en: "A logistics startup in Tokyo",
+    },
+    summary: {
+      ja: [
+        "物流業界に特化したスタートアップで、自社プロダクトの SaaS、toC メディア、官公庁向け情報ポータルの開発を担当。",
+        "フロントエンド・バックエンド・インフラ・CI/CD まで一貫して責任を持つスタイル。",
+        "直近では官公庁ドメイン（go.jp）の本番構築・SES 認証メール基盤を主導。",
+        "エンジニア採用、中途入社者の OJT、インターンや若手のマネジメントといった組織面も担当。",
+      ],
+      en: [
+        "Building proprietary SaaS, consumer media, and a government information portal at a logistics-focused startup.",
+        "End-to-end ownership across frontend, backend, infrastructure, and CI/CD.",
+        "Recently led the production launch on a go.jp domain and the SES email authentication stack.",
+        "Also responsible for engineering hiring, OJT for mid-career hires, and mentorship of interns and junior engineers.",
+      ],
+    },
+    domains: ["Frontend", "Backend", "Infra (AWS)", "SEO", "Hiring", "Onboarding", "Mentorship"],
+  },
+  {
+    id: "ses-frontend-engineer",
+    period: { start: "2022-01", end: "2024-06" },
+    role: {
+      ja: "フロントエンドエンジニア",
+      en: "Frontend Engineer",
+    },
+    org: {
+      ja: "SES企業",
+      en: "Contract engineering firm",
+    },
+    summary: {
+      ja: [
+        "大手企業常駐案件で、生成 AI チャットアプリケーション、業務系 Web アプリケーション、社内ツールのフロントエンド開発を担当。",
+        "大規模データ（数万件規模）のパフォーマンス改善、ロール／ポリシー単位の RBAC 実装、E2E テスト整備を経験。",
+        "AWS 認定資格を3冠取得（SAA / DVA / SOA）。社内 LT 大会の主催も担当。",
+      ],
+      en: [
+        "Built frontends for enterprise-embedded projects: a generative-AI chat application, business web apps, and internal tools.",
+        "Optimized rendering of tens of thousands of records, implemented role/policy-based RBAC, and established E2E testing.",
+        "Earned three AWS Associate certifications (SAA / DVA / SOA); organized an internal lightning-talk meetup.",
+      ],
+    },
+    domains: ["Frontend", "Testing"],
+  },
+  {
+    id: "math-teacher",
+    period: { start: "2018-04", end: "2021-10" },
+    role: {
+      ja: "数学科教員",
+      en: "Math Teacher",
+    },
+    org: {
+      ja: "地方の公立中学校",
+      en: "Public middle school in a rural part of Japan",
+    },
+    summary: {
+      ja: [
+        "地方の公立中学校で数学を教える3年間。「どの順番で説明すれば伝わるか」を毎日設計。",
+        "ここで身についたもの: 伝え方の設計、ドキュメント文化。",
+      ],
+      en: [
+        "Taught math for three years at a public middle school in a rural part of Japan, designing daily how to land an explanation.",
+        "Skills earned: explanation design, documentation culture.",
+      ],
+    },
+    domains: ["Teaching", "Documentation"],
+  },
+];

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -5,3 +5,79 @@
   text-underline-offset: -0.2em; /* 線の位置。テキストに重なるようにやや上部にする */
   text-decoration-skip-ink: none; /* 下線と文字列が重なる部分でも下線が省略されない（線が途切れない） */
 }
+
+/* details の滑らか開閉。interpolate-size は Chromium 系のみ対応。
+   非対応ブラウザでは即時開閉のままで体験が壊れない */
+:root {
+  interpolate-size: allow-keywords;
+}
+
+details::details-content {
+  block-size: 0;
+  overflow: clip;
+  transition: block-size 250ms ease, content-visibility 250ms ease allow-discrete;
+}
+
+details[open]::details-content {
+  block-size: auto;
+}
+
+/* 全インタラクティブ要素に共通のフォーカスリングを当てる。a11y のベースライン */
+a:focus-visible,
+button:focus-visible,
+summary:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid #82DBD8; /* base-color */
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.dark a:focus-visible,
+.dark button:focus-visible,
+.dark summary:focus-visible,
+.dark [role="button"]:focus-visible {
+  outline-color: #2F8F9D; /* primary */
+}
+
+/* reduced-motion ユーザーには全アニメ・トランジションを止める */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* 印刷スタイル。採用担当の PDF 化を想定して、装飾を抑えて読みやすく */
+@media print {
+  header,
+  footer,
+  .no-print {
+    display: none !important;
+  }
+  body {
+    color: #000 !important;
+    background: #fff !important;
+  }
+  a {
+    color: #000 !important;
+    text-decoration: underline;
+  }
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.85em;
+    color: #555;
+  }
+  section {
+    page-break-inside: avoid;
+  }
+  details > summary {
+    list-style: none;
+  }
+  details > summary::-webkit-details-marker {
+    display: none;
+  }
+}

--- a/src/types/about.ts
+++ b/src/types/about.ts
@@ -1,0 +1,119 @@
+// aboutページで使う多言語対応データの型定義
+
+// 多言語テキスト
+export type LocalizedText = { ja: string; en: string };
+export type LocalizedTextArray = { ja: string[]; en: string[] };
+
+// ヒーローセクション
+export type HeroProfile = {
+  name: string;
+  nameAlt: LocalizedText;
+  badges: string[];
+  catchphrase: LocalizedText;
+  subText: LocalizedText;
+  location: string;
+};
+
+// 自己紹介
+export type AboutMeBody = {
+  paragraphs: LocalizedTextArray;
+  hobbies: LocalizedText;
+};
+
+// ミッション
+export type Mission = {
+  headline: LocalizedText;
+  body: LocalizedTextArray;
+  principles: LocalizedTextArray;
+};
+
+// キャリアタイムライン
+export type TimelineEntry = {
+  id: string;
+  period: { start: string; end: string | null };
+  role: LocalizedText;
+  org: LocalizedText;
+  summary: LocalizedTextArray;
+  domains: string[];
+};
+
+// スキルスタック
+export type SkillLevel = "main" | "sub" | "learning";
+
+export type SkillGroup = {
+  level: SkillLevel;
+  category: LocalizedText;
+  items: string[];
+};
+
+export type StrengthArea = {
+  title: LocalizedText;
+  description: LocalizedText;
+};
+
+// プロジェクト
+export type Project = {
+  id: string;
+  title: LocalizedText;
+  period: LocalizedText;
+  role: LocalizedText;
+  scale: LocalizedTextArray;
+  rationale: LocalizedTextArray;
+  result?: LocalizedText;
+  stack: string[];
+};
+
+export type OtherProject = {
+  id: string;
+  title: LocalizedText;
+  summary: LocalizedText;
+};
+
+// 資格
+export type Credential = {
+  id: string;
+  title: LocalizedText;
+  acquiredAt: string;
+  url?: string;
+};
+
+// アウトプット（登壇・執筆・選抜・主催）
+export type OutputKind = "writing" | "speaking" | "selection" | "organize";
+
+export type OutputEntry = {
+  id: string;
+  kind: OutputKind;
+  title: LocalizedText;
+  date: string;
+  url?: string;
+  summary?: LocalizedText;
+};
+
+// Nowセクション
+export type NowItem = {
+  category: LocalizedText;
+  body: LocalizedText;
+};
+
+export type Now = {
+  intro: LocalizedText;
+  items: NowItem[];
+  lastUpdated: string;
+};
+
+// コンタクト
+export type ContactChannelKind = "form" | "email" | "social";
+
+export type ContactChannel = {
+  kind: ContactChannelKind;
+  label: LocalizedText;
+  href: string;
+};
+
+export type Contact = {
+  intro: LocalizedTextArray;
+  acceptedTopics: LocalizedTextArray;
+  declinedTopics: LocalizedTextArray;
+  channels: ContactChannel[];
+  responseSla: LocalizedText;
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,7 +1,8 @@
-import { clsx } from "clsx";
+import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export const cltw = (...inputs: (string | undefined)[]) => {
+// 条件式（boolean）も受け取れるよう ClassValue で受ける
+export const cltw = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs));
 }
 


### PR DESCRIPTION
## Summary
- about ページを 6 セクション構成に刷新（Hero / 自己紹介 / Mission / Career / Skills / Contact）
- 多言語対応の静的データを `src/static/about/` に、型を `src/types/about.ts` に集約
- 共通の `Chip` に `noTruncate` プロパティを追加し、長い技術名タグも省略しない選択肢を用意
- グローバル CSS にフォーカスリング統一・`prefers-reduced-motion`・印刷スタイル・`<details>` 開閉トランジションを追加
- about ページ専用の Person JSON-LD と metadata（title / OG / Twitter card / alternates）を実装

## Test plan
- [ ] `npm run dev` で `/ja/about` / `/en/about` を開く
- [ ] モバイル（375px）・タブレット（768px）・PC（1280px）の各ブレークポイントで崩れがない
- [ ] ライト / ダークモード両方でコントラストが保たれる
- [ ] `npm run e2e -- about` で ABOUT-01〜08 が通る
- [ ] `npm run build` でビルド成功（既存の `open-next.config.ts` の型問題は本 PR スコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)