### PR TITLE
fix: og:url/canonical をサイト全体でページ固有の絶対URLに修正

### DIFF
--- a/src/app/[locale]/about/layout.tsx
+++ b/src/app/[locale]/about/layout.tsx
@@ -26,16 +26,16 @@ export async function generateMetadata({ params }: AboutLayoutProps): Promise<Me
         en: `${baseURL}/en/about`,
       },
     },
+    // og:image は同セグメントの opengraph-image.tsx が自動生成・付与するため images は指定しない
     openGraph: {
       url: `${baseURL}/${locale}/about`,
       title: t('pageTitle'),
       description: t('pageDescription'),
-      images: [{ url: `${baseURL}/og-image.png`, width: 1200, height: 630 }],
+      siteName: 'Ryota-Blog',
       type: 'profile',
     },
     twitter: {
       card: 'summary_large_image',
-      images: [`${baseURL}/og-image.png`],
     },
   };
 }

--- a/src/app/[locale]/about/opengraph-image.tsx
+++ b/src/app/[locale]/about/opengraph-image.tsx
@@ -1,0 +1,108 @@
+import { ImageResponse } from "next/og";
+import { getTranslations } from "next-intl/server";
+
+import { AUTHOR_NAME, AUTHOR_NAME_EN } from "@/static/blogs";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  // Next.js 16ではparamsがPromiseになるため、awaitで解決
+  const { locale } = await params;
+
+  // Kosugi Maru フォントをGoogle Fonts CDNから取得
+  // Cloudflare Workersランタイムでは fs.readFileSync が使用不可のためfetchで代替
+  const fontResponse = await fetch(
+    "https://fonts.gstatic.com/s/kosugimaru/v17/0nksC9PgP_wGh21A2KeqGiTq.ttf",
+    { cf: { cacheTtl: 86400 } } as RequestInit,
+  );
+  if (!fontResponse.ok) {
+    throw new Error(`フォントの取得に失敗しました: ${fontResponse.status}`);
+  }
+  const fontData = await fontResponse.arrayBuffer();
+
+  // localeに基づいて作者名・ページタイトルを選択
+  const authorName = locale === "en" ? AUTHOR_NAME_EN : AUTHOR_NAME;
+  const t = await getTranslations({ locale, namespace: "about" });
+  const title = t("pageTitle");
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          position: "relative",
+          background: "white",
+          color: "black",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          paddingBottom: "80px",
+          borderTop: "84px solid rgb(59 172 182)",
+          borderBottom: "84px solid rgb(59 172 182)",
+          borderLeft: "96px solid rgb(59 172 182)",
+          borderRight: "96px solid rgb(59 172 182)",
+          borderRadius: "16px",
+          fontSize: "48px",
+          fontWeight: "bold",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            margin: "5px",
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            WebkitLineClamp: 3,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            position: "absolute",
+            right: "20px",
+            bottom: "20px",
+            display: "flex",
+            alignItems: "center",
+            gap: "20px",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="https://images.microcms-assets.io/assets/4626924a681346e9a0fcabe5478eb9fa/652ac7c701f14f858ad1cbb1ece163c6/author.png"
+            width="100"
+            height="100"
+            style={{
+              width: "100px",
+              height: "100px",
+              borderRadius: "50%",
+            }}
+            alt="Icon"
+          />
+          <p>{authorName}</p>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: "Kosugi Maru",
+          data: fontData,
+        },
+      ],
+    },
+  );
+}

--- a/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 
 import ArticleBody from "@/components/ArticleBody";
 import BreadcrumbList from "@/components/BreadcrumbList";
-import { generateBreadcrumbAssets, getPrimaryCategoryId } from "@/lib";
+import { generateBreadcrumbAssets, getPrimaryCategoryId, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import { getBlogByIdByLocale, getAllBlogListByLocale } from "@/lib/microcms";
 import type { BlogsContentType } from "@/types/microcms";
 import JsonLD from "@/components/Head/JsonLD";
@@ -42,17 +42,28 @@ export async function generateMetadata(
   const { blogId, locale, category } = await params;
   const data = await getBlogByIdByLocale(locale, blogId, { fields: "title,description,noIndex" });
 
+  // 記事自身の絶対URL（og:url / canonical に使用）
+  const blogUrl = buildPageUrl(locale, "blogs", category, blogId);
+
   return {
     title: data.title,
     description: data.description,
     robots: data.noIndex ? "noindex" : null,
     alternates: {
-      languages: Object.fromEntries(
-        locales.map((loc) => [
-          loc,
-          `/${loc}/blogs/${category}/${blogId}`
-        ])
-      )
+      canonical: blogUrl,
+      languages: buildLanguageAlternates("blogs", category, blogId)
+    },
+    // openGraph は子で定義すると親（ルートレイアウト）の値が置換されるため siteName/type も明示する。
+    // 画像は同セグメントの opengraph-image.tsx / twitter-image.tsx が自動付与するため images は指定しない
+    openGraph: {
+      url: blogUrl,
+      title: data.title,
+      description: data.description,
+      siteName: "Ryota-Blog",
+      type: "article"
+    },
+    twitter: {
+      card: "summary_large_image"
     }
   };
 }
@@ -114,7 +125,7 @@ const Page = async ({ params }: PageProps) => {
           <RelatedContentList data={data.relatedContent} />
         </aside>
       )}
-      <JsonLD data={data} />
+      <JsonLD data={data} locale={locale} />
     </div>
   );
 };

--- a/src/app/[locale]/blogs/[category]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page.tsx
@@ -9,7 +9,7 @@ import Skelton from "@/components/ArticleList/skelton";
 import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
 import ZennArticleList from "@/components/ZennArticleList";
-import { generateQuery } from "@/lib";
+import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import { BLOG_TYPE_QUERY, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY, CATEGORY_MAPED_NAME, CATEGORY_MAPED_ID } from "@/static/blogs";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
 import type { MappedKeyLiteralType } from "@/types/microcms";
@@ -57,10 +57,17 @@ export async function generateMetadata(
   const page = resolvedSearchParams.page || null;
   const keyword = resolvedSearchParams.keyword || null;
 
+  // canonical / og:url は検索・ページのクエリを含めず素のカテゴリURLに正規化して集約する
+  const categoryUrl = buildPageUrl(locale, "blogs", category);
+  const categoryLanguages = buildLanguageAlternates("blogs", category);
+
   if (blogType === "zenn") {
     return {
       title: t('zennArticles'),
-      description: t('zennArticles')
+      description: t('zennArticles'),
+      alternates: { canonical: categoryUrl, languages: categoryLanguages },
+      openGraph: { url: categoryUrl, title: t('zennArticles'), description: t('zennArticles'), siteName: "Ryota-Blog", type: "website" },
+      twitter: { card: "summary_large_image" },
     }
   }
 
@@ -69,13 +76,16 @@ export async function generateMetadata(
     return {
       title,
       description: translatedCategoryName,
-      robots: page ? "noindex" : "index"
+      robots: page ? "noindex" : "index",
+      alternates: { canonical: categoryUrl, languages: categoryLanguages },
+      openGraph: { url: categoryUrl, title, description: translatedCategoryName, siteName: "Ryota-Blog", type: "website" },
+      twitter: { card: "summary_large_image" },
     }
   }
 
   let title = page ? ` - ${t('page')} ${page}` : ""
   let description = ""
-  
+
   if (keyword) {
     title = `${translatedCategoryName} & ${keyword}` + title
     description = `${translatedCategoryName} & ${keyword}`
@@ -84,7 +94,10 @@ export async function generateMetadata(
   return {
     title: title,
     description: description,
-    robots: page ? "noindex" : "index"
+    robots: page ? "noindex" : "index",
+    alternates: { canonical: categoryUrl, languages: categoryLanguages },
+    openGraph: { url: categoryUrl, title, description, siteName: "Ryota-Blog", type: "website" },
+    twitter: { card: "summary_large_image" },
   }
 }
 

--- a/src/app/[locale]/blogs/[category]/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page/[page]/page.tsx
@@ -8,7 +8,7 @@ import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
 import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
-import { generateQuery } from "@/lib";
+import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import { getBlogListByLocale } from "@/lib/microcms";
 import { PER_PAGE, CATEGORY_MAPED_NAME, CATEGORY_MAPED_ID } from "@/static/blogs";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
@@ -69,19 +69,18 @@ export async function generateMetadata(
     translatedCategoryName = categoryName;
   }
 
+  const pageUrl = buildPageUrl(locale, "blogs", category, "page", page);
+  const title = `${translatedCategoryName} - ${t('page')} ${page}`;
+
   return {
-    title: `${translatedCategoryName} - ${t('page')} ${page}`,
-    description: `${translatedCategoryName} - ${t('page')} ${page}`,
+    title,
+    description: title,
     robots: "noindex",
     alternates: {
-      canonical: `/${locale}/blogs/${category}/page/${page}`,
-      languages: Object.fromEntries(
-        locales.map((loc) => [
-          loc,
-          `/${loc}/blogs/${category}/page/${page}`
-        ])
-      )
-    }
+      canonical: pageUrl,
+      languages: buildLanguageAlternates("blogs", category, "page", page)
+    },
+    openGraph: { url: pageUrl, title, description: title, siteName: "Ryota-Blog", type: "website" }
   };
 }
 

--- a/src/app/[locale]/blogs/page.tsx
+++ b/src/app/[locale]/blogs/page.tsx
@@ -8,7 +8,7 @@ import Skelton from "@/components/ArticleList/skelton";
 import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
 import ZennArticleList from "@/components/ZennArticleList";
-import { generateQuery } from "@/lib";
+import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import {
   BLOG_TYPE_QUERY,
   CATEGORY_QUERY,
@@ -53,19 +53,31 @@ export async function generateMetadata({
   const category = resolvedSearchParams.category || null;
   const keyword = resolvedSearchParams.keyword || null;
 
+  // canonical / og:url は検索・カテゴリ・ページのクエリを含めず素の /blogs に正規化して集約する
+  const blogsUrl = buildPageUrl(locale, "blogs");
+  const blogsLanguages = buildLanguageAlternates("blogs");
+
   // NOTE: ?blogType=zenn にアクセスした場合
   if (blogType === "zenn") {
     return {
       title: t("zennArticles"),
       description: t("zennArticles"),
+      alternates: { canonical: blogsUrl, languages: blogsLanguages },
+      openGraph: { url: blogsUrl, title: t("zennArticles"), description: t("zennArticles"), siteName: "Ryota-Blog", type: "website" },
+      twitter: { card: "summary_large_image" },
     };
   }
   // NOTE: /blogs にアクセスした場合
   if (blogType === "blogs" && !category && !keyword) {
+    const title = page ? `${t("recentPosts")} - ${t("page")} ${page}` : "HOME";
+    const description = tMeta("siteDescription");
     return {
-      title: page ? `${t("recentPosts")} - ${t("page")} ${page}` : "HOME",
-      description: tMeta("siteDescription"),
+      title,
+      description,
       robots: page ? "noindex" : "index",
+      alternates: { canonical: blogsUrl, languages: blogsLanguages },
+      openGraph: { url: blogsUrl, title, description, siteName: "Ryota-Blog", type: "website" },
+      twitter: { card: "summary_large_image" },
     };
   }
 
@@ -107,6 +119,9 @@ export async function generateMetadata({
     title: title,
     description: description,
     robots: page ? "noindex" : "index",
+    alternates: { canonical: blogsUrl, languages: blogsLanguages },
+    openGraph: { url: blogsUrl, title, description, siteName: "Ryota-Blog", type: "website" },
+    twitter: { card: "summary_large_image" },
   };
 }
 

--- a/src/app/[locale]/blogs/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/page/[page]/page.tsx
@@ -7,7 +7,7 @@ import { getTranslations } from 'next-intl/server';
 import ArticleList from "@/components/ArticleList";
 import Skelton from "@/components/ArticleList/skelton";
 import SideNav from "@/components/SideNav";
-import { generateQuery } from "@/lib";
+import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
 import { getBlogListByLocale } from "@/lib/microcms";
 import { PER_PAGE } from "@/static/blogs";
@@ -39,20 +39,19 @@ export async function generateMetadata(
   // Next.js 16では、paramsを非同期で取得する必要がある
   const { locale, page } = await params;
   const t = await getTranslations({ locale, namespace: 'blog' });
-  
+
+  const pageUrl = buildPageUrl(locale, "blogs", "page", page);
+  const title = `${t('recentPosts')} - ${t('page')} ${page}`;
+
   return {
-    title: `${t('recentPosts')} - ${t('page')} ${page}`,
-    description: `${t('recentPosts')} - ${t('page')} ${page}`,
+    title,
+    description: title,
     robots: "noindex",
     alternates: {
-      canonical: `/${locale}/blogs/page/${page}`,
-      languages: Object.fromEntries(
-        locales.map((loc) => [
-          loc,
-          `/${loc}/blogs/page/${page}`
-        ])
-      )
-    }
+      canonical: pageUrl,
+      languages: buildLanguageAlternates("blogs", "page", page)
+    },
+    openGraph: { url: pageUrl, title, description: title, siteName: "Ryota-Blog", type: "website" }
   };
 }
 

--- a/src/app/[locale]/blogs/zenn/page.tsx
+++ b/src/app/[locale]/blogs/zenn/page.tsx
@@ -5,6 +5,7 @@ import SideNav from "@/components/SideNav";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
 import ZennArticleList from "@/components/ZennArticleList";
 import SearchStateCard from "@/components/SearchStateCard";
+import { buildPageUrl } from "@/lib";
 
 interface ZennPageProps {
   params: Promise<{
@@ -19,11 +20,15 @@ export async function generateMetadata({ params }: ZennPageProps): Promise<Metad
   // Next.js 16では、paramsを非同期で取得する必要がある
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'blog' });
-  
+
+  const zennUrl = buildPageUrl(locale, "blogs", "zenn");
+
   return {
     title: t('zennArticles'),
     description: t('zennArticles'),
-    robots: "noindex"
+    robots: "noindex",
+    alternates: { canonical: zennUrl },
+    openGraph: { url: zennUrl, title: t('zennArticles'), description: t('zennArticles'), siteName: "Ryota-Blog", type: "website" }
   };
 }
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -28,10 +28,16 @@ export async function generateMetadata({ params }: LocaleLayoutProps): Promise<M
     },
     description: t('siteDescription'),
     metadataBase: new URL(baseURL),
+    // og:url はページ固有のため各ページの generateMetadata で設定する。
+    // ここでは openGraph を定義しないページ向けのデフォルト値（site名・タイトル等）のみ保持する
     openGraph: {
-      url: baseURL,
+      title: t('siteTitle'),
+      description: t('siteDescription'),
       siteName: 'Ryota-Blog',
       type: 'website'
+    },
+    twitter: {
+      card: 'summary_large_image'
     }
   };
 }

--- a/src/app/feed/route.ts
+++ b/src/app/feed/route.ts
@@ -38,7 +38,8 @@ export async function GET() {
     feed.addItem({
       id: blog.id,
       title: blog.title,
-      link: `${baseURL}/blogs/${categoryId}/${blog.id}`,
+      // 実ルーティング（/[locale]/blogs/...）に合わせ、既定ロケール ja 込みのURLにする
+      link: `${baseURL}/ja/blogs/${categoryId}/${blog.id}`,
       description: blog.description,
       date: new Date(blog.publishedAt || blog.updatedAt),
     });

--- a/src/components/Head/JsonLD/index.tsx
+++ b/src/components/Head/JsonLD/index.tsx
@@ -1,19 +1,22 @@
 import type { BreadcrumbList, BlogPosting, WithContext, WebSite } from "schema-dts"
 import type { BlogsContentType } from "@/types/microcms"
-import { baseURL } from "@/config"
 import { SITE_TITLE, CATEGORY_MAPED_NAME } from "@/static/blogs"
-import { getPrimaryCategoryId } from "@/lib"
+import { getPrimaryCategoryId, buildPageUrl } from "@/lib"
 import Script from "next/script"
 
 
 type JsonLDProps = {
   data: BlogsContentType
+  locale: string
 }
 
-const JsonLD = ({ data }: JsonLDProps) => {
+const JsonLD = ({ data, locale }: JsonLDProps) => {
   const categoryId = getPrimaryCategoryId(data);
   const categoryName = CATEGORY_MAPED_NAME[categoryId];
-  
+  // 構造化データのURLは実ルーティング（/[locale]/blogs/...）に合わせて locale 込みで構築する
+  const articleUrl = buildPageUrl(locale, "blogs", categoryId, data.id);
+  const authorUrl = buildPageUrl(locale, "about");
+
   const breadcrumbJsonLD: WithContext<BreadcrumbList> = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
@@ -22,19 +25,19 @@ const JsonLD = ({ data }: JsonLDProps) => {
         "@type": "ListItem",
         position: 1,
         name: "Home",
-        item: `${baseURL}/blogs`
+        item: buildPageUrl(locale, "blogs")
       },
       {
         "@type": "ListItem",
         position: 2,
         name: categoryName,
-        item: `${baseURL}/blogs/${categoryId}`
+        item: buildPageUrl(locale, "blogs", categoryId)
       },
       {
         "@type": "ListItem",
         position: 3,
         name: data.title,
-        item: `${baseURL}/blogs/${categoryId}/${data.id}`
+        item: articleUrl
       }
     ]
   }
@@ -44,7 +47,7 @@ const JsonLD = ({ data }: JsonLDProps) => {
     "@type": "BlogPosting",
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": `${baseURL}/blogs/${categoryId}/${data.id}`
+      "@id": articleUrl
     },
     headline: data.title,
     datePublished: data.publishedAt || data.updatedAt,
@@ -56,7 +59,7 @@ const JsonLD = ({ data }: JsonLDProps) => {
       "@type": "Person",
       name: "Ryota",
       jobTitle: "Software Engineer",
-      url: `${baseURL}/about`
+      url: authorUrl
     },
   }
 
@@ -64,12 +67,12 @@ const JsonLD = ({ data }: JsonLDProps) => {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: SITE_TITLE,
-    url: baseURL,
+    url: buildPageUrl(locale),
     publisher: {
       "@type": "Person",
       name: "Ryota",
       jobTitle: "Software Engineer",
-      url: `${baseURL}/about`
+      url: authorUrl
     },
   }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,8 @@ import { getTranslations } from 'next-intl/server';
 import type { BreadcrumbItemType, TOCAssetsType } from "@/types";
 import { CATEGORY_MAPED_ID, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY, PER_PAGE, CATEGORY_MAPED_NAME } from "@/static/blogs";
 import type { MappedKeyLiteralType, BlogsContentType } from "@/types/microcms";
+import { baseURL } from "@/config";
+import { locales } from "@/i18n/config";
 
 export const generateTOCAssets = (html: string) => {
   // 正規表現を使用して<h2>または<h3>タグのidとテキストを抽出
@@ -112,3 +114,14 @@ export const pickHostname = (url: string) => {
   const _url = new URL(url);
   return _url.hostname;
 }
+
+// ロケールとパスセグメントから絶対URLを構築する
+// 例: buildPageUrl('ja', 'blogs', 'programming', 'abc') => https://ryotablog.jp/ja/blogs/programming/abc
+export const buildPageUrl = (locale: string, ...segments: string[]): string => {
+  const path = segments.filter(Boolean).join("/");
+  return `${baseURL}/${locale}${path ? `/${path}` : ""}`;
+}
+
+// 全ロケール分の hreflang(languages) マップを生成する
+export const buildLanguageAlternates = (...segments: string[]): Record<string, string> =>
+  Object.fromEntries(locales.map((loc) => [loc, buildPageUrl(loc, ...segments)]));


### PR DESCRIPTION
## 背景 / 問題
全ページが `og:url = https://ryotablog.jp`（トップ固定）を出力し、記事ページに `<link rel="canonical">` が無かったため、iframely / SNS / LINE のリンク展開や検索エンジンが「**全記事＝トップ**」と誤認し、カードのタイトル・説明がトップの「HOME | Ryota-Blog」になっていた。SEO/拡散の両面で実害があった。

### 根本原因
- ルートレイアウト `src/app/[locale]/layout.tsx` の `generateMetadata` が `openGraph.url = baseURL`（トップ固定）を返していた。
- 記事詳細をはじめ各ページに `openGraph` / `alternates.canonical` が無く、Next.js のメタデータ継承で親レイアウトの固定 `og:url` が全ページに出力されていた。

## 変更内容
### コア（og:url / canonical 正常化・locale込み絶対URL）
- **`src/lib/index.ts`**: `buildPageUrl` / `buildLanguageAlternates` ヘルパーを新設
- **`[locale]/layout.tsx`**: 固定 `og:url` を削除。`siteName`/`type`/`title`/`description` をデフォルト化、`twitter` 追加
- **`…/[category]/[blogId]/page.tsx`**（本丸）: canonical + `openGraph`(type=article) + `twitter` を追加、`JsonLD` に `locale` を渡す
- **`…/blogs/page.tsx` / `…/[category]/page.tsx`**: canonical を素のURL（searchParams除外）に正規化 + openGraph + twitter
- **ページネーション2ファイル / `…/zenn/page.tsx`**: canonical をヘルパー化 + openGraph 追加（`robots: noindex` 維持）
- **`Head/JsonLD/index.tsx`**: 構造化データの全URLを locale込み（`buildPageUrl`）に統一

> Next.js 仕様上 `openGraph` は子で定義すると親が**置換**されるため、各ページで `siteName`/`type` を再掲。`og:image` は各 `opengraph-image.tsx` がファイルベースで自動付与するため `images` は明示せず。

### 周辺の既存バグ修正
- **`…/about/opengraph-image.tsx`（新規）**: 実在しない `public/og-image.png` 参照で壊れていた about の og:image を、動的生成（`ImageResponse`）に置き換え
- **`…/about/layout.tsx`**: 壊れた `og-image.png` 参照を撤去
- **`src/app/feed/route.ts`**: RSS記事リンクを locale込みURL（`/ja/blogs/...`）に修正

## 検証
- `tsc --noEmit`: 変更ファイルに型エラーなし
- `next build`: コンパイル成功・TypeScript通過・**91/122ページの静的生成に成功**（停止は microCMS の 429 レート制限によるもので、記事数×並列フェッチ起因。実装の回帰ではない）
- デプロイ後に iframely / X Card Validator で記事URLを再取得し、各記事の正しいタイトル・説明・画像でカード表示されることを確認予定

## 補足（スコープ外）
- ビルドログで `MISSING_MESSAGE: categories.ui-parts (ja)`（`categories` 翻訳の `ui-parts` キー欠落）という既存の翻訳欠落を発見。本PRのスコープ外のため別途対応推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)