### PR TITLE
fix: 記事内テーブルのモバイル横スクロールを解消

### DIFF
--- a/src/components/ArticleBody/RichEditor/CustomUI/Table/CustomTable.tsx
+++ b/src/components/ArticleBody/RichEditor/CustomUI/Table/CustomTable.tsx
@@ -3,9 +3,12 @@ import { type ComponentProps } from "react";
 type CustomTableProps = ComponentProps<"table">
 
 const CustomTable = ({ children, ...restProps }: CustomTableProps) => {
-  // NOTE: 固定px幅をやめ、利用可能な幅いっぱいに広げて横はみ出し時のみスクロールさせる
+  // NOTE: モバイルでテーブルの固有幅（whitespace-nowrapヘッダー由来）がページ幅を超えると、
+  // 祖先のmx-auto flexアイテムがshrink-to-fitして横スクロールが発生していた。
+  // コードブロック(MultiCodeBlock)と同じく viewport基準の確定max-width で
+  // スクロールコンテナの幅を固定し、広いテーブルはこのボックス内でのみ横スクロールさせる。
   return (
-    <div className="flex my-4 w-full max-w-full overflow-x-auto">
+    <div className="my-4 w-full max-w-[83vw] sm:max-w-[600px] md:max-w-[730px] lg:max-w-[1028px] overflow-x-auto">
       <table {...restProps} className="table-auto w-full indent-0 border-collapse border-inherit">
         {children}
       </table>


### PR DESCRIPTION
## 概要
記事詳細ページ（モバイル）で、navヘッダーよりコンテンツ領域が広くなり不要な横スクロールが発生していた問題を修正。

## 原因
- `CustomTable` のラッパー `flex my-4 w-full max-w-full overflow-x-auto` に、モバイルで効く確定幅の上限が無かった（`max-w-full`=100% は内容依存の親に対して無意味）。
- `<th>` の `whitespace-nowrap` により `table-auto` テーブルが固有幅 417px を持ち、mobile幅(375px)を超過。
- その幅が祖先の `max-w-[1028px] mx-auto` flexアイテム（auto マージンで shrink-to-fit）まで漏れ、ページ全体が膨張 → 横スクロール発生。

## 修正
スクロールコンテナにviewport基準の確定 `max-width` キャップを付与し（`MultiCodeBlock` と同パターン）、`flex` を除去。広いテーブルはボックス内でのみ横スクロールするように。

```diff
- <div className="flex my-4 w-full max-w-full overflow-x-auto">
+ <div className="my-4 w-full max-w-[83vw] sm:max-w-[600px] md:max-w-[730px] lg:max-w-[1028px] overflow-x-auto">
```

## 検証（ローカルdevで実コンパイルしたCSSで計測）
| | 修正前 | 修正後 |
|---|---|---|
| モバイル375px ページ横はみ出し | 94px | **0px** |
| デスクトップ1280px | 0px | **0px**（回帰なし）|
| テーブル | ページ幅を破壊 | ボックス内で内部スクロール |

モバイル/デスクトップ両方でスクリーンショット目視確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)