### PR TITLE
fix(ci): Cloudflare deploy ステップに3回リトライを追加

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,4 +42,23 @@ jobs:
           NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npm run deploy:${{ steps.set-env.outputs.env }}
+        # Cloudflare API への一過性エラー（R2 populate-cache での "Premature close" 等）に対して、
+        # 最大3回・30秒間隔で自動リトライする。1回で成功すれば追加コストはゼロ。
+        run: |
+          set +e
+          for attempt in 1 2 3; do
+            echo "::group::Deploy attempt $attempt of 3"
+            npm run deploy:${{ steps.set-env.outputs.env }}
+            exit_code=$?
+            echo "::endgroup::"
+            if [ $exit_code -eq 0 ]; then
+              echo "✅ Deploy succeeded on attempt $attempt"
+              exit 0
+            fi
+            if [ $attempt -lt 3 ]; then
+              echo "⚠️ Deploy failed (exit $exit_code), retrying in 30s..."
+              sleep 30
+            fi
+          done
+          echo "❌ Deploy failed after 3 attempts"
+          exit 1


### PR DESCRIPTION
## Summary

- Cloudflare Workers へのデプロイステップで、Cloudflare API の一過性エラー（例：R2 `populate-cache` 中の `Premature close`）が原因で workflow が失敗するケースに対応
- 失敗時に **最大3回・30秒間隔で自動リトライ** するシェルループを `Build and Deploy to Cloudflare Workers` ステップに追加

## 背景

[Run #27890526105](https://github.com/ryota-09/ryota-blog/actions/runs/27890526105/job/84230324533) で以下のエラーが発生：

\`\`\`
Error: Failed to provision remote R2 bucket "ryota-blog-cache-prd" for binding "NEXT_INC_CACHE_R2_BUCKET":
Failed to check whether bucket exists:
Invalid response body while trying to fetch https://api.cloudflare.com/client/v4/accounts/***/r2/buckets/ryota-blog-cache-prd:
Premature close
\`\`\`

- ビルド・バンドルは成功、最後の R2 バケット存在チェック API コールがネットワーク早期切断で失敗
- R2 バケットは実在しており、コード起因ではない一過性エラー
- 同種の一過性失敗が今後も起き得るため、手動 rerun に依存しない自動リカバリを入れたい

## 変更内容

`Build and Deploy to Cloudflare Workers` ステップの `run:` を、シェルベースのリトライループに置換。

- 最大 **3 回** 試行
- 失敗時は **30 秒** 待機して再試行
- 1 回で成功すれば追加コストはゼロ
- 全試行失敗時は exit 1 で workflow を fail させる（永続的エラーは検知される）

外部 action 依存なし。

## Test plan

- [ ] このPRをマージ → develop に変更が乗る
- [ ] その後 main / staging へのpushでDeploy ワークフローが新ロジックで動くことを確認
- [ ] 通常時は1回目で成功して所要時間に変化なし
- [ ] 万一一過性エラー発生時に自動リトライされて成功するログを後日観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)