### PR TITLE
fix(ci): populate-cache 持続障害時に wrangler 直接 deploy へフォールバック

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,17 +42,29 @@ jobs:
           NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        # デプロイ戦略：
-        # 1. OpenNext deploy（populate-cache 含む）を最大2回試行（一過性ネットワークエラーの自動復旧）
-        # 2. それでも失敗したら、build → wrangler 直接 deploy で populate-cache を bypass
-        #    （Cloudflare R2 API の持続的エラーから本番デプロイを守るフェイルセーフ）
-        # ※ fallback時は ISR cache populate がスキップされ、新規ページのISR初回アクセスが多少遅くなる。
-        #   次の OpenNext deploy 成功時に R2 cache は populate される。
+        # デプロイ戦略（Cloudflare R2 incremental cache の持続障害対応・3段ハイブリッド）：
+        #
+        # 背景：2026-06-18頃から Cloudflare R2 incremental cache populate で持続的なエラー
+        # （`Premature close` / 503 / timeout）が発生中。upstream [Issue #1284](
+        # https://github.com/opennextjs/opennextjs-cloudflare/issues/1284) でも複数報告あり、
+        # OpenNext maintainer の推奨ワークアラウンドは `--cacheChunkSize` で concurrency を最小化。
+        #
+        # この workflow は upstream 推奨に従いつつ、最悪ケースでも本番デプロイが確保できるよう
+        # 3段構えで保護する：
+        #
+        # 1. OpenNext deploy with `--cacheChunkSize 1`（最小 concurrency）を2回試行
+        #    → 通常時はここで成功（concurrency が下がってもコストはわずか）
+        # 2. それでも失敗したら、wrangler 直接 deploy で populate-cache 全bypass
+        #    → Workers コードは最新、ISR cache は前回キャッシュ流用（次回成功時に正常化）
+        # 3. fallback 経路も失敗したら exit 1
         run: |
           set +e
+          CONFIG="wrangler.${{ steps.set-env.outputs.env }}.jsonc"
+
           for attempt in 1 2; do
-            echo "::group::OpenNext deploy attempt $attempt of 2"
-            npm run deploy:${{ steps.set-env.outputs.env }}
+            echo "::group::OpenNext deploy attempt $attempt of 2 (cacheChunkSize=1)"
+            npx opennextjs-cloudflare build --config "$CONFIG" && \
+              npx opennextjs-cloudflare deploy --config "$CONFIG" --cacheChunkSize 1
             exit_code=$?
             echo "::endgroup::"
             if [ $exit_code -eq 0 ]; then
@@ -64,22 +76,25 @@ jobs:
               sleep 30
             fi
           done
-          echo "::warning::OpenNext deploy failed twice. Falling back to direct wrangler deploy (bypasses populate-cache). ISR cache may stay stale for new pages until the next successful OpenNext deploy."
+
+          echo "::warning::OpenNext deploy failed twice (even with --cacheChunkSize 1). Falling back to direct wrangler deploy (bypasses populate-cache). ISR cache may stay stale for new pages until the next successful OpenNext deploy."
+
           echo "::group::Rebuild for wrangler-direct fallback"
-          npx opennextjs-cloudflare build --config wrangler.${{ steps.set-env.outputs.env }}.jsonc
+          npx opennextjs-cloudflare build --config "$CONFIG"
           build_exit=$?
           echo "::endgroup::"
           if [ $build_exit -ne 0 ]; then
             echo "❌ OpenNext build failed during fallback (exit $build_exit)"
             exit $build_exit
           fi
+
           echo "::group::wrangler deploy (fallback)"
-          npx wrangler deploy --config wrangler.${{ steps.set-env.outputs.env }}.jsonc
+          npx wrangler deploy --config "$CONFIG"
           deploy_exit=$?
           echo "::endgroup::"
           if [ $deploy_exit -eq 0 ]; then
             echo "✅ Wrangler direct deploy succeeded (fallback)"
             exit 0
           fi
-          echo "❌ Both OpenNext deploy (2x) and wrangler direct deploy failed"
+          echo "❌ Both OpenNext deploy (2x with cacheChunkSize=1) and wrangler direct deploy failed"
           exit 1

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,23 +42,44 @@ jobs:
           NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        # Cloudflare API への一過性エラー（R2 populate-cache での "Premature close" 等）に対して、
-        # 最大3回・30秒間隔で自動リトライする。1回で成功すれば追加コストはゼロ。
+        # デプロイ戦略：
+        # 1. OpenNext deploy（populate-cache 含む）を最大2回試行（一過性ネットワークエラーの自動復旧）
+        # 2. それでも失敗したら、build → wrangler 直接 deploy で populate-cache を bypass
+        #    （Cloudflare R2 API の持続的エラーから本番デプロイを守るフェイルセーフ）
+        # ※ fallback時は ISR cache populate がスキップされ、新規ページのISR初回アクセスが多少遅くなる。
+        #   次の OpenNext deploy 成功時に R2 cache は populate される。
         run: |
           set +e
-          for attempt in 1 2 3; do
-            echo "::group::Deploy attempt $attempt of 3"
+          for attempt in 1 2; do
+            echo "::group::OpenNext deploy attempt $attempt of 2"
             npm run deploy:${{ steps.set-env.outputs.env }}
             exit_code=$?
             echo "::endgroup::"
             if [ $exit_code -eq 0 ]; then
-              echo "✅ Deploy succeeded on attempt $attempt"
+              echo "✅ OpenNext deploy succeeded on attempt $attempt"
               exit 0
             fi
-            if [ $attempt -lt 3 ]; then
-              echo "⚠️ Deploy failed (exit $exit_code), retrying in 30s..."
+            if [ $attempt -lt 2 ]; then
+              echo "⚠️ OpenNext deploy failed (exit $exit_code), retrying in 30s..."
               sleep 30
             fi
           done
-          echo "❌ Deploy failed after 3 attempts"
+          echo "::warning::OpenNext deploy failed twice. Falling back to direct wrangler deploy (bypasses populate-cache). ISR cache may stay stale for new pages until the next successful OpenNext deploy."
+          echo "::group::Rebuild for wrangler-direct fallback"
+          npx opennextjs-cloudflare build --config wrangler.${{ steps.set-env.outputs.env }}.jsonc
+          build_exit=$?
+          echo "::endgroup::"
+          if [ $build_exit -ne 0 ]; then
+            echo "❌ OpenNext build failed during fallback (exit $build_exit)"
+            exit $build_exit
+          fi
+          echo "::group::wrangler deploy (fallback)"
+          npx wrangler deploy --config wrangler.${{ steps.set-env.outputs.env }}.jsonc
+          deploy_exit=$?
+          echo "::endgroup::"
+          if [ $deploy_exit -eq 0 ]; then
+            echo "✅ Wrangler direct deploy succeeded (fallback)"
+            exit 0
+          fi
+          echo "❌ Both OpenNext deploy (2x) and wrangler direct deploy failed"
           exit 1


### PR DESCRIPTION
## Summary

Cloudflare R2 API の **持続的なエラー** (`Premature close`) で `populate-cache` が失敗してデプロイがブロックされる事象に対処。

- **2 回**まで OpenNext deploy（populate-cache 含む）を試行
- それでも失敗した場合は **wrangler 直接 deploy** へフォールバックし、populate-cache を bypass して本番デプロイを通す

## 背景

[Run #28430884358](https://github.com/ryota-09/ryota-blog/actions/runs/28430884358) で、先行PR #202 のリトライ機構（3回）を導入後も、**3回連続で全く同じ `Premature close` エラー** で失敗。一過性ではなく Cloudflare R2 API 側の持続的問題と判定。

\`\`\`
Error: Failed to provision remote R2 bucket "ryota-blog-cache-prd" for binding "NEXT_INC_CACHE_R2_BUCKET":
Failed to check whether bucket exists:
Invalid response body while trying to fetch https://api.cloudflare.com/client/v4/accounts/***/r2/buckets/ryota-blog-cache-prd:
Premature close
\`\`\`

OpenNext (`@opennextjs/cloudflare@1.19.0`) の `deploy`/`upload` 両コマンドは内部で `populateCache` を必須呼出しており、CLI でのスキップ不可（[ソース確認済](https://github.com/opennextjs/opennextjs-cloudflare/blob/v1.19.0/packages/cloudflare/src/cli/commands/deploy.ts)）。

このため、最終手段として **wrangler 直接 deploy** で populate-cache を bypass し、本番デプロイを確保するフェイルセーフを追加。

## 変更内容

\`Build and Deploy to Cloudflare Workers\` ステップを次の2段構えに変更。

\`\`\`
1. OpenNext deploy （populate-cache 含む）を 2 回試行
   - 1回目成功 → 通常コスト
   - 2回目で成功 → 30秒待機して再試行で復旧
2. 2回とも失敗 → wrangler 直接 deploy
   - `opennextjs-cloudflare build` で .open-next/worker.js を再生成
   - `wrangler deploy` で Worker のみアップロード（populate-cache スキップ）
3. fallback も失敗 → exit 1
\`\`\`

## トレードオフ

- ✅ Cloudflare R2 API の持続的障害があっても、Workers のコード自体は最新版がデプロイされる
- ⚠️ fallback 時は ISR cache populate がスキップされる。新規ページのISR初回アクセスが多少遅くなるが、次回 OpenNext deploy 成功時に正常化
- ✅ 通常時は1回で成功して所要時間に変化なし

## Test plan

- [ ] このPRをマージ → develop に変更が乗る
- [ ] その後 main へ反映 → Cloudflare deploy ワークフローが新ロジックで動くことを確認
- [ ] Cloudflare 側の障害が継続中なら fallback で wrangler 直接 deploy が走り、本番が更新されることを確認
- [ ] Cloudflare 復旧後、通常ルートで populate-cache が成功することを確認

## 関連

- 先行PR: #202（リトライ機構追加）
- 失敗 run: [27890526105](https://github.com/ryota-09/ryota-blog/actions/runs/27890526105)（初回） / [28430884358](https://github.com/ryota-09/ryota-blog/actions/runs/28430884358)（リトライ後も失敗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)