### PR TITLE
fix(ci): R2 populate-cache 持続障害対応（cacheChunkSize=1 + wrangler 直接 deploy フォールバック）

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,23 +42,59 @@ jobs:
           NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        # Cloudflare API への一過性エラー（R2 populate-cache での "Premature close" 等）に対して、
-        # 最大3回・30秒間隔で自動リトライする。1回で成功すれば追加コストはゼロ。
+        # デプロイ戦略（Cloudflare R2 incremental cache の持続障害対応・3段ハイブリッド）：
+        #
+        # 背景：2026-06-18頃から Cloudflare R2 incremental cache populate で持続的なエラー
+        # （`Premature close` / 503 / timeout）が発生中。upstream [Issue #1284](
+        # https://github.com/opennextjs/opennextjs-cloudflare/issues/1284) でも複数報告あり、
+        # OpenNext maintainer の推奨ワークアラウンドは `--cacheChunkSize` で concurrency を最小化。
+        #
+        # この workflow は upstream 推奨に従いつつ、最悪ケースでも本番デプロイが確保できるよう
+        # 3段構えで保護する：
+        #
+        # 1. OpenNext deploy with `--cacheChunkSize 1`（最小 concurrency）を2回試行
+        #    → 通常時はここで成功（concurrency が下がってもコストはわずか）
+        # 2. それでも失敗したら、wrangler 直接 deploy で populate-cache 全bypass
+        #    → Workers コードは最新、ISR cache は前回キャッシュ流用（次回成功時に正常化）
+        # 3. fallback 経路も失敗したら exit 1
         run: |
           set +e
-          for attempt in 1 2 3; do
-            echo "::group::Deploy attempt $attempt of 3"
-            npm run deploy:${{ steps.set-env.outputs.env }}
+          CONFIG="wrangler.${{ steps.set-env.outputs.env }}.jsonc"
+
+          for attempt in 1 2; do
+            echo "::group::OpenNext deploy attempt $attempt of 2 (cacheChunkSize=1)"
+            npx opennextjs-cloudflare build --config "$CONFIG" && \
+              npx opennextjs-cloudflare deploy --config "$CONFIG" --cacheChunkSize 1
             exit_code=$?
             echo "::endgroup::"
             if [ $exit_code -eq 0 ]; then
-              echo "✅ Deploy succeeded on attempt $attempt"
+              echo "✅ OpenNext deploy succeeded on attempt $attempt"
               exit 0
             fi
-            if [ $attempt -lt 3 ]; then
-              echo "⚠️ Deploy failed (exit $exit_code), retrying in 30s..."
+            if [ $attempt -lt 2 ]; then
+              echo "⚠️ OpenNext deploy failed (exit $exit_code), retrying in 30s..."
               sleep 30
             fi
           done
-          echo "❌ Deploy failed after 3 attempts"
+
+          echo "::warning::OpenNext deploy failed twice (even with --cacheChunkSize 1). Falling back to direct wrangler deploy (bypasses populate-cache). ISR cache may stay stale for new pages until the next successful OpenNext deploy."
+
+          echo "::group::Rebuild for wrangler-direct fallback"
+          npx opennextjs-cloudflare build --config "$CONFIG"
+          build_exit=$?
+          echo "::endgroup::"
+          if [ $build_exit -ne 0 ]; then
+            echo "❌ OpenNext build failed during fallback (exit $build_exit)"
+            exit $build_exit
+          fi
+
+          echo "::group::wrangler deploy (fallback)"
+          npx wrangler deploy --config "$CONFIG"
+          deploy_exit=$?
+          echo "::endgroup::"
+          if [ $deploy_exit -eq 0 ]; then
+            echo "✅ Wrangler direct deploy succeeded (fallback)"
+            exit 0
+          fi
+          echo "❌ Both OpenNext deploy (2x with cacheChunkSize=1) and wrangler direct deploy failed"
           exit 1


### PR DESCRIPTION
## Summary

Cloudflare R2 incremental cache populate での持続的エラー（`Premature close` / 503 / timeout）に対し、**3段ハイブリッド戦略**で本番デプロイを守る。

1. **`--cacheChunkSize 1`** で concurrency を最小化して OpenNext deploy を **2回** 試行
2. それでも失敗したら **wrangler 直接 deploy** で populate-cache を bypass
3. それも失敗したら exit 1

## 背景：Web調査で判明した upstream の確認済み regression

[opennextjs-cloudflare#1284](https://github.com/opennextjs/opennextjs-cloudflare/issues/1284) で **2026-06-19** から **複数ユーザーが同種エラー** を報告中（11日経過もまだ未解決）。

| 観点 | 内容 |
|---|---|
| **根本原因（OpenNext maintainer `james-elicx` の解析）** | 「高並行性で**帯域・ソケットが枯渇**、リクエストが15秒間byteを送れず abort される」。Cloudflare R2 受信側の **infrastructure regression**（2026-06-18から）|
| **upstream 推奨ワークアラウンド** | `--cacheChunkSize 5` または **`--cacheChunkSize 1`**（FredKSchott / Cloudflare team の提案）|
| **downgrade 効果** | **無し**（複数報告で確認済み）。infrastructure 側の問題なので |
| **Cloudflare 公式対応** | P1サポートチケット open 中も未解決 |

我々の ryota-blog でも [Run #28430884358](https://github.com/ryota-09/ryota-blog/actions/runs/28430884358) で **3回連続で同一 `Premature close` エラー**（先行 PR #202 のリトライ機構導入後）が発生。同根の問題と判定。

## 変更内容

\`Build and Deploy to Cloudflare Workers\` ステップを次の3段構えに刷新。

\`\`\`
1. opennextjs-cloudflare build && deploy --cacheChunkSize 1
   ├─ 成功 → 終了（通常時）
   └─ 失敗 → 30s wait → 2回目試行
2. 2回目失敗 → fallback へ
3. opennextjs-cloudflare build （.open-next/worker.js 再生成）
4. wrangler deploy 直接 = populate-cache bypass
   ├─ 成功 → 終了（最新Worker稼働 / ISR cache は前回のまま）
   └─ 失敗 → exit 1
\`\`\`

`--cacheChunkSize 1` は upstream maintainer 推奨の concurrency 抑制パラメータ。1回目で成功確率が高まる想定。

## トレードオフ

- ✅ Cloudflare R2 持続障害でも Workers のコードは最新版がデプロイされる
- ✅ 通常時は1回目で成功するため追加コストはわずか（concurrency 抑制でやや時間長くなる可能性あり）
- ⚠️ fallback 時は ISR cache populate がスキップされ、新規ページのISR初回アクセスがやや遅い（次回成功時に正常化）
- ⚠️ `--cacheChunkSize 1` で cache populate 時間は伸びる（このサイトは静的ページ数 130 程度なので体感差は小さい想定）

## Test plan

- [ ] このPRをマージ → develop に変更が乗る
- [ ] その後 main へ反映 → Cloudflare deploy ワークフローが新ロジックで動くことを確認
- [ ] Cloudflare R2 障害が継続中なら fallback で wrangler 直接 deploy が走り、本番が更新されることを確認
- [ ] Cloudflare 復旧後、通常ルート（cacheChunkSize=1, 1回目成功）で動くことを確認

## 関連

- 先行PR: #202（リトライ機構追加・マージ済）
- 失敗 run: [27890526105](https://github.com/ryota-09/ryota-blog/actions/runs/27890526105) / [28430884358](https://github.com/ryota-09/ryota-blog/actions/runs/28430884358)
- Closed: PR #204（このPRに統合）
- Upstream issue: [opennextjs-cloudflare#1284](https://github.com/opennextjs/opennextjs-cloudflare/issues/1284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)