### PR TITLE
fix(ci): wrangler fallback に --no-x-provision を追加（R2 auto-provisioning も bypass）

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -44,19 +44,20 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         # デプロイ戦略（Cloudflare R2 incremental cache の持続障害対応・3段ハイブリッド）：
         #
-        # 背景：2026-06-18頃から Cloudflare R2 incremental cache populate で持続的なエラー
-        # （`Premature close` / 503 / timeout）が発生中。upstream [Issue #1284](
-        # https://github.com/opennextjs/opennextjs-cloudflare/issues/1284) でも複数報告あり、
-        # OpenNext maintainer の推奨ワークアラウンドは `--cacheChunkSize` で concurrency を最小化。
+        # 背景：2026-06-18頃から Cloudflare R2 API で持続的なエラー（`Premature close`）が発生中。
+        # upstream [Issue #1284](https://github.com/opennextjs/opennextjs-cloudflare/issues/1284) で
+        # 複数報告あり、OpenNext maintainer の推奨ワークアラウンドは `--cacheChunkSize` で
+        # concurrency を最小化。
         #
-        # この workflow は upstream 推奨に従いつつ、最悪ケースでも本番デプロイが確保できるよう
-        # 3段構えで保護する：
-        #
+        # 3段戦略：
         # 1. OpenNext deploy with `--cacheChunkSize 1`（最小 concurrency）を2回試行
-        #    → 通常時はここで成功（concurrency が下がってもコストはわずか）
-        # 2. それでも失敗したら、wrangler 直接 deploy で populate-cache 全bypass
-        #    → Workers コードは最新、ISR cache は前回キャッシュ流用（次回成功時に正常化）
+        # 2. それでも失敗したら、wrangler 直接 deploy with `--no-x-provision`
+        #    （wrangler の自動 R2 provisioning も bypass する真の bypass）
         # 3. fallback 経路も失敗したら exit 1
+        #
+        # 注：単純な wrangler deploy も内部で R2 binding の provision を試みるため、
+        # `--no-x-provision` が必須（[Cloudflare changelog 2025-10-24](
+        # https://developers.cloudflare.com/changelog/post/2025-10-24-automatic-resource-provisioning/) 参照）。
         run: |
           set +e
           CONFIG="wrangler.${{ steps.set-env.outputs.env }}.jsonc"
@@ -77,7 +78,7 @@ jobs:
             fi
           done
 
-          echo "::warning::OpenNext deploy failed twice (even with --cacheChunkSize 1). Falling back to direct wrangler deploy (bypasses populate-cache). ISR cache may stay stale for new pages until the next successful OpenNext deploy."
+          echo "::warning::OpenNext deploy failed twice (even with --cacheChunkSize 1). Falling back to direct wrangler deploy with --no-x-provision (bypasses both populate-cache and R2 bucket provisioning). ISR cache may stay stale for new pages until the next successful OpenNext deploy."
 
           echo "::group::Rebuild for wrangler-direct fallback"
           npx opennextjs-cloudflare build --config "$CONFIG"
@@ -88,13 +89,13 @@ jobs:
             exit $build_exit
           fi
 
-          echo "::group::wrangler deploy (fallback)"
-          npx wrangler deploy --config "$CONFIG"
+          echo "::group::wrangler deploy --no-x-provision (fallback)"
+          npx wrangler deploy --config "$CONFIG" --no-x-provision
           deploy_exit=$?
           echo "::endgroup::"
           if [ $deploy_exit -eq 0 ]; then
             echo "✅ Wrangler direct deploy succeeded (fallback)"
             exit 0
           fi
-          echo "❌ Both OpenNext deploy (2x with cacheChunkSize=1) and wrangler direct deploy failed"
+          echo "❌ Both OpenNext deploy (2x with cacheChunkSize=1) and wrangler direct deploy (--no-x-provision) failed"
           exit 1


### PR DESCRIPTION
## Summary

PR #205 でマージした 3段ハイブリッドの **fallback ステップ** がまだ `Premature close` で失敗していた。原因は **wrangler 自身も deploy 時に R2 binding の auto-provisioning を試みる** ことが判明。

→ `wrangler deploy --no-x-provision` フラグで auto-provisioning を skip して、真の bypass を実現する。

## 背景：PR #205 後の失敗 run 分析

[Run #28432054962](https://github.com/ryota-09/ryota-blog/actions/runs/28432054962) のログより：

\`\`\`
##[group]wrangler deploy (fallback)
⛅ wrangler 4.81.1
throw new Error(`Failed to provision remote R2 bucket "${bucketName}" for binding "${R2_CACHE_BINDING_NAME}": ${result.error}`);
Error: Failed to provision remote R2 bucket "ryota-blog-cache-prd" for binding "NEXT_INC_CACHE_R2_BUCKET": 
       Failed to check whether bucket exists: ... : Premature close
\`\`\`

OpenNext を bypass しても、**wrangler 内部の R2 auto-provisioning** が同じ Cloudflare R2 API を叩いて Premature close で失敗。

## 解決策

[Cloudflare changelog 2025-10-24](https://developers.cloudflare.com/changelog/post/2025-10-24-automatic-resource-provisioning/) で導入された **automatic resource provisioning** 機能は、`--no-x-provision` フラグで明示的に無効化できる：

\`\`\`bash
wrangler deploy --config ... --no-x-provision
\`\`\`

これにより、wrangler は既存の R2 bucket binding を **存在チェックせずそのまま** Worker に bind する。R2 bucket 自体は既に存在しているため、deploy 完了後の runtime でも問題なく動作する。

## 変更内容

`deploy-cloudflare.yml` の fallback ステップを以下に変更：

\`\`\`diff
- npx wrangler deploy --config "\$CONFIG"
+ npx wrangler deploy --config "\$CONFIG" --no-x-provision
\`\`\`

## トレードオフ

- ✅ Cloudflare R2 API が完全に死んでいても Workers コードのデプロイは通る（auto-provisioning を完全skip）
- ✅ 既存の R2 bucket binding は引き続き機能（Worker runtime では正常）
- ⚠️ R2 bucket が新規追加された場合は事前に手動作成が必要（auto-provisioning が走らないため）。現状は既存 bucket のみなので影響なし
- ✅ Cloudflare 復旧後、通常ルート（OpenNext deploy + cacheChunkSize=1）で1回目から成功する想定

## Test plan

- [ ] マージ → develop → main で deploy ワークフロー実行
- [ ] Cloudflare R2 障害継続中なら、fallback で `wrangler deploy --no-x-provision` が走り、本番が更新されることを確認
- [ ] runtime で R2 binding が引き続き機能していることを確認（既存 ISR cache が読まれる）

## 関連

- 先行PR: #202（リトライ追加・マージ済）, #205（cacheChunkSize=1 + fallback・マージ済）
- Closed: #204（#205に統合）
- 失敗 run: [#28432054962](https://github.com/ryota-09/ryota-blog/actions/runs/28432054962)
- Upstream issue: [opennextjs-cloudflare#1284](https://github.com/opennextjs/opennextjs-cloudflare/issues/1284)
- 参考: [Cloudflare automatic resource provisioning changelog](https://developers.cloudflare.com/changelog/post/2025-10-24-automatic-resource-provisioning/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)