### PR TITLE
fix(ci): R2 deploy 障害対応 — OPEN_NEXT_DEPLOY=true で真の bypass

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,44 +42,46 @@ jobs:
           NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        # デプロイ戦略（Cloudflare R2 incremental cache の持続障害対応・3段ハイブリッド）：
+        # デプロイ戦略（Cloudflare R2 incremental cache の持続障害対応・2段ハイブリッド）:
         #
-        # 背景：2026-06-18頃から Cloudflare R2 API で持続的なエラー（`Premature close`）が発生中。
-        # upstream [Issue #1284](https://github.com/opennextjs/opennextjs-cloudflare/issues/1284) で
-        # 複数報告あり、OpenNext maintainer の推奨ワークアラウンドは `--cacheChunkSize` で
-        # concurrency を最小化。
+        # 背景：2026-06-18頃から Cloudflare R2 API（bucket existence check）で持続的な
+        # `Premature close` エラーが発生中。upstream [Issue #1284](
+        # https://github.com/opennextjs/opennextjs-cloudflare/issues/1284) で複数報告あり。
+        # 2026-06-30 時点の最新コメントで `--cacheChunkSize 1` でも失敗する旨が報告されたため、
+        # 旧戦略の concurrency 下げは無効と判明。
         #
-        # 3段戦略：
-        # 1. OpenNext deploy with `--cacheChunkSize 1`（最小 concurrency）を2回試行
-        # 2. それでも失敗したら、wrangler 直接 deploy with `--no-x-provision`
-        #    （wrangler の自動 R2 provisioning も bypass する真の bypass）
-        # 3. fallback 経路も失敗したら exit 1
+        # 2段戦略：
+        # 1. OpenNext deploy（populate-cache 含む）を1回試行
+        #    → R2 API 復旧時はここで成功
+        # 2. 失敗したら、`OPEN_NEXT_DEPLOY=true` を立てて wrangler 直接 deploy
+        #    → このフラグは OpenNext 自身が再帰回避用に内部で使うフラグで、
+        #      wrangler 4.81+ の OpenNext auto-detection を bypass する
+        #      （参照: [opennextjs-cloudflare deploy.ts L64-73](
+        #      https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/cli/commands/deploy.ts#L64-L73)）。
+        #      worker のみ deploy され、populate-cache は呼ばれない。
+        #      ISR cache は前回成功時の状態を維持（次回 OpenNext deploy 成功で更新）。
+        # 3. fallback も失敗したら exit 1
         #
-        # 注：単純な wrangler deploy も内部で R2 binding の provision を試みるため、
-        # `--no-x-provision` が必須（[Cloudflare changelog 2025-10-24](
-        # https://developers.cloudflare.com/changelog/post/2025-10-24-automatic-resource-provisioning/) 参照）。
+        # 注：従来 PR #205-207 で試した `--cacheChunkSize 1` retry と `--no-x-provision` は
+        # 効果がないことが判明（前者は #1284 で確認、後者は wrangler の OpenNext detection に
+        # 巻き込まれ populate-cache が再呼び出しされた）。本実装はそれらを撤去している。
         run: |
           set +e
           CONFIG="wrangler.${{ steps.set-env.outputs.env }}.jsonc"
 
-          for attempt in 1 2; do
-            echo "::group::OpenNext deploy attempt $attempt of 2 (cacheChunkSize=1)"
-            npx opennextjs-cloudflare build --config "$CONFIG" && \
-              npx opennextjs-cloudflare deploy --config "$CONFIG" --cacheChunkSize 1
-            exit_code=$?
-            echo "::endgroup::"
-            if [ $exit_code -eq 0 ]; then
-              echo "✅ OpenNext deploy succeeded on attempt $attempt"
-              exit 0
-            fi
-            if [ $attempt -lt 2 ]; then
-              echo "⚠️ OpenNext deploy failed (exit $exit_code), retrying in 30s..."
-              sleep 30
-            fi
-          done
+          echo "::group::OpenNext deploy (with populate-cache)"
+          npx opennextjs-cloudflare build --config "$CONFIG" && \
+            npx opennextjs-cloudflare deploy --config "$CONFIG"
+          exit_code=$?
+          echo "::endgroup::"
+          if [ $exit_code -eq 0 ]; then
+            echo "✅ OpenNext deploy succeeded (R2 incremental cache populated)"
+            exit 0
+          fi
 
-          echo "::warning::OpenNext deploy failed twice (even with --cacheChunkSize 1). Falling back to direct wrangler deploy with --no-x-provision (bypasses both populate-cache and R2 bucket provisioning). ISR cache may stay stale for new pages until the next successful OpenNext deploy."
+          echo "::warning::OpenNext deploy failed (likely R2 API regression #1284). Falling back to OPEN_NEXT_DEPLOY=true wrangler deploy. ISR cache will stay at the previous successful deploy's state until the next OpenNext deploy succeeds."
 
+          # build artifact が残っているはずなのでそのまま使う。安全のため再 build。
           echo "::group::Rebuild for wrangler-direct fallback"
           npx opennextjs-cloudflare build --config "$CONFIG"
           build_exit=$?
@@ -89,13 +91,13 @@ jobs:
             exit $build_exit
           fi
 
-          echo "::group::wrangler deploy --no-x-provision (fallback)"
-          npx wrangler deploy --config "$CONFIG" --no-x-provision
+          echo "::group::OPEN_NEXT_DEPLOY=true wrangler deploy (true bypass)"
+          OPEN_NEXT_DEPLOY=true npx wrangler deploy --config "$CONFIG"
           deploy_exit=$?
           echo "::endgroup::"
           if [ $deploy_exit -eq 0 ]; then
-            echo "✅ Wrangler direct deploy succeeded (fallback)"
+            echo "✅ Wrangler direct deploy succeeded (fallback). NOTE: R2 incremental cache not populated this run."
             exit 0
           fi
-          echo "❌ Both OpenNext deploy (2x with cacheChunkSize=1) and wrangler direct deploy (--no-x-provision) failed"
+          echo "❌ Both OpenNext deploy and OPEN_NEXT_DEPLOY=true wrangler deploy failed"
           exit 1


### PR DESCRIPTION
## Summary

PR #207 で追加した `wrangler deploy --no-x-provision` fallback が **wrangler 4.81.1 の OpenNext auto-detection に巻き込まれて再帰的に `opennextjs-cloudflare deploy` を呼び出し**、populate-cache が起動して同じ R2 Premature close でこける問題を修正。

### 失敗ログ (run 28432516366)

```
##[group]wrangler deploy --no-x-provision (fallback)
 ⛅️ wrangler 4.81.1 (update available 4.105.0)
OpenNext project detected, calling `opennextjs-cloudflare deploy`
...
Populating remote R2 incremental cache...
Error: Failed to provision remote R2 bucket "ryota-blog-cache-prd"
       for binding "NEXT_INC_CACHE_R2_BUCKET":
       Failed to check whether bucket exists: ... Premature close
```

### 修正内容

1. **`OPEN_NEXT_DEPLOY=true` 環境変数を fallback の wrangler deploy に付与**
   - OpenNext 自身が再帰回避のために内部で使用するフラグ
   - 参照: [opennextjs-cloudflare deploy.ts L64-73](https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/cli/commands/deploy.ts#L64-L73)
   - これで wrangler が auto-detection をスキップし、worker のみを deploy する（populate-cache 呼ばれない）

2. **`--cacheChunkSize 1` retry を撤去**
   - upstream [#1284 最新コメント](https://github.com/opennextjs/opennextjs-cloudflare/issues/1284) で `--cacheChunkSize 1` でも失敗することが確認された
   - 2回試行 → 1回に削減（無駄な待機時間カット）

3. **`--no-x-provision` フラグを撤去**
   - OpenNext auto-detection に巻き込まれる経路では効果がない

### トレードオフ

fallback 経路では **R2 incremental cache は更新されない** → 新規ページのISR初回が遅くなる可能性。次回 OpenNext deploy 成功時に正常化する。Workers コード（記事の表示ロジック）は最新が反映されるので、microCMS 動的取得の記事は問題なく更新される。

### 上流の状況

- Cloudflare R2 API（bucket existence check）の 持続障害は 2026-06-18 から継続
- Cloudflare 中の人（@FredKSchott）が internal で調査中
- upstream の修正 PR はまだなし

## Test plan

- [ ] develop branch へマージ後、stg 環境への deploy で fallback 経路が動くことを確認（または OpenNext deploy が成功すれば step 1 で終わる）
- [ ] main へマージ後、prd への deploy 成功を確認
- [ ] R2 API 復旧後、ISR cache が次回 deploy で正常 populate されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)