### PR TITLE
fix: ページ遷移直後の画像チラつきをスケルトンローディングで解消

### DIFF
--- a/src/app/[locale]/about/_components/HeroSection/index.tsx
+++ b/src/app/[locale]/about/_components/HeroSection/index.tsx
@@ -24,8 +24,10 @@ const HeroSection = ({ locale }: HeroSectionProps) => {
           alt={`${nameAlt} のプロフィール写真`}
           width={96}
           height={96}
-          className="aspect-square w-20 shrink-0 rounded-full object-cover shadow-md"
-          priority
+          className="aspect-square w-20 rounded-full object-cover shadow-md"
+          wrapperClassName="shrink-0"
+          skeletonClassName="rounded-full"
+          preload
         />
         <div>
           <h1
@@ -71,7 +73,8 @@ const HeroSection = ({ locale }: HeroSectionProps) => {
             width={280}
             height={280}
             className="aspect-square w-[200px] md:w-[280px] rounded-full object-cover shadow-2xl"
-            priority
+            skeletonClassName="rounded-full"
+            preload
           />
         </figure>
       </div>

--- a/src/components/ArticleBody/BottomCard/index.tsx
+++ b/src/components/ArticleBody/BottomCard/index.tsx
@@ -1,20 +1,22 @@
 import { AUTHOR_DESCRIPTION, AUTHOR_DESCRIPTION_EN, AUTHOR_NAME, AUTHOR_NAME_EN } from "@/static/blogs";
-import Image from "next/image";
+import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton";
 import { useLocale } from 'next-intl';
 
 const BottomCard = () => {
   const locale = useLocale();
-  
+
   return (
     <>
       <div className="mx-6 flex shrink-0 items-center justify-center">
-        <Image
+        <ImageWithSkeleton
           src="/author.png"
           alt="author"
           width={80}
           height={80}
           sizes="100vw"
           className="rounded-full"
+          wrapperClassName=""
+          skeletonClassName="rounded-full"
         />
       </div>
       <div>

--- a/src/components/ArticleBody/RichEditor/CustomUI/CustomImg/index.tsx
+++ b/src/components/ArticleBody/RichEditor/CustomUI/CustomImg/index.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton";
 import { type ComponentProps } from "react";
 
 type CustomImgProps = { src: string, alt: string, width: string, height: string } & Omit<ComponentProps<"img">, "src" | "alt" | "width" | "height">
@@ -8,8 +8,28 @@ const CustomImg = ({ src, alt, width, height, ...restProps }: CustomImgProps) =>
   const isGif = src.endsWith(".gif");
   return (
     <p className="flex justify-center my-8">
-      {/* NOTE: モバイルで横幅をはみ出さないよう max-w-full / h-auto を付与（md以上は70%幅） */}
-      <Image src={src} alt={alt} width={+width} height={+height} unoptimized={isGif} loading="lazy" className="max-w-full h-auto md:w-[70%]"  {...restProps} />
+      {/*
+        NOTE: サイズ指定クラス（モバイルで横幅をはみ出さない max-w-full / md以上は70%幅）は
+        ラッパー側（wrapperClassName）に持たせる。flex中央寄せの親の直下にパーセンテージ幅を
+        持つ画像を直接置くと、スケルトン用ラッパーの shrink-to-fit と幅解決が循環してしまうため、
+        70%幅の解決を wrapper の1階層に固定し、画像自体は wrapper を w-full で埋めるだけにする。
+
+        NOTE: {...restProps} は明示指定のprops（src/alt/width/height/className等）より
+        必ず前に展開すること。custom HTML area機能でCMS本文の<img>にclass属性が付与されていた場合、
+        html-react-parserがそれをclassName propに変換してrestPropsに含めるため、後ろに置くと
+        意図したclassName="h-auto w-full"（横はみ出し防止の要）が上書きされてしまう。
+      */}
+      <ImageWithSkeleton
+        {...restProps}
+        src={src}
+        alt={alt}
+        width={+width}
+        height={+height}
+        unoptimized={isGif}
+        loading="lazy"
+        wrapperClassName="max-w-full md:w-[70%]"
+        className="h-auto w-full"
+      />
     </p>
   )
 }

--- a/src/components/ArticleBody/ThumbnailCard/index.tsx
+++ b/src/components/ArticleBody/ThumbnailCard/index.tsx
@@ -1,5 +1,5 @@
 import { AUTHOR_NAME } from "@/static/blogs";
-import Image from "next/image";
+import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton";
 
 type ThumbnailCardProps = {
   /**
@@ -15,13 +15,15 @@ const ThumbnailCard = ({ title }: ThumbnailCardProps) => {
         {title}
       </h1>
       <div className="mx-4 mb-4 flex items-center justify-end gap-4 sm:m-6">
-        <Image
+        <ImageWithSkeleton
           src="/author.png"
           alt="author"
           width={80}
           height={80}
           sizes="100vw"
           className="w-[50px] rounded-full md:w-[80px]"
+          wrapperClassName=""
+          skeletonClassName="rounded-full"
         />
         <p className="text-lg font-bold md:text-3xl dark:text-gray-300">
           {AUTHOR_NAME}

--- a/src/components/ArticleBody/index.tsx
+++ b/src/components/ArticleBody/index.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton";
 
 import RichEditor from "@/components/ArticleBody/RichEditor";
 import ThumbnailCard from '@/components/ArticleBody/ThumbnailCard';
@@ -42,8 +42,8 @@ const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
           ?
           <div className="flex flex-col gap-8">
             <h1 className="text-2xl md:text-3xl font-bold dark:text-gray-300">{data.title}</h1>
-            <figure className="max-h-[300px] md:max-h-[540px] overflow-hidden shadow-2xl">
-              <Image
+            <figure className="relative max-h-[300px] md:max-h-[540px] overflow-hidden shadow-2xl">
+              <ImageWithSkeleton
                 src={data.thumbnail.url}
                 alt={data.title}
                 width={data.thumbnail.width}
@@ -51,7 +51,7 @@ const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
                 sizes="100vw"
                 style={{ height: "auto", width: "100%" }}
                 loading="eager"
-                priority
+                preload
               />
             </figure>
           </div>

--- a/src/components/ArticleList/ArticleCard/index.tsx
+++ b/src/components/ArticleList/ArticleCard/index.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { useState } from "react";
 import { Link } from "next-view-transitions";
 import { useLocale, useTranslations } from "next-intl";
 
 import { BlogsContentType } from "@/types/microcms";
 import NewLabel from "@/components/UiParts/NewLabel";
+import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton";
 import { isWithinTwoWeeks } from "@/util";
 import { getPrimaryCategoryId } from "@/lib";
 import { getBlogPath } from "@/lib/i18n-utils";
-import Image from "next/image";
 
 type ArticleCardProps = {
   /**
@@ -23,7 +22,6 @@ type ArticleCardProps = {
 };
 
 const ArticleCard = ({ data, index }: ArticleCardProps) => {
-  const [isImageLoaded, setIsImageLoaded] = useState(false);
   const locale = useLocale();
   const t = useTranslations("blog");
   const categoryId = getPrimaryCategoryId(data);
@@ -32,6 +30,11 @@ const ArticleCard = ({ data, index }: ArticleCardProps) => {
   // LCP最適化: モバイル（1列）は最初の1枚、デスクトップ（2列）は最初の2枚がLCP候補
   // SSR時に正しい値を出力する必要があるため、両方をカバーするindex <= 1を使用
   const isLcpCandidate = index <= 1;
+  // loading/fetchPriority/preload はLCP候補かどうかで常にセットで一致すべき値のため、
+  // 個別の三項演算子に分散させず1箇所にまとめて導出する（将来どれか1つだけ変更されるズレを防ぐ）
+  const lcpImageProps = isLcpCandidate
+    ? { loading: "eager" as const, fetchPriority: "high" as const, preload: true }
+    : { loading: "lazy" as const, fetchPriority: "auto" as const, preload: false };
 
   return (
     <div className="relative flex h-[540px] flex-col border-2 border-gray-200 bg-white p-6 dark:dark:border-gray-600 dark:bg-black md:h-[290px]">
@@ -68,14 +71,7 @@ const ArticleCard = ({ data, index }: ArticleCardProps) => {
               className="flex h-full w-full flex-grow items-center justify-center"
             >
               <figure className="relative w-full transition-opacity hover:opacity-80">
-                {/* スケルトン: LCP候補以外の画像のみ表示（LCP候補はフェードインをスキップ） */}
-                {!isLcpCandidate && !isImageLoaded && (
-                  <div
-                    className="absolute inset-0 -z-10 animate-pulse bg-gray-200 dark:bg-gray-600"
-                    aria-hidden="true"
-                  />
-                )}
-                <Image
+                <ImageWithSkeleton
                   src={data.thumbnail.url}
                   alt={data.title}
                   width={data.thumbnail.width}
@@ -85,17 +81,7 @@ const ArticleCard = ({ data, index }: ArticleCardProps) => {
                     width: "100%",
                     height: "auto",
                   }}
-                  className={
-                    // LCP候補は常にopacity-100（フェードインによるRender delay回避）
-                    isLcpCandidate
-                      ? "opacity-100"
-                      : !isImageLoaded
-                        ? "opacity-0 transition-opacity duration-500"
-                        : "opacity-100"
-                  }
-                  onLoad={() => setIsImageLoaded(true)}
-                  loading={isLcpCandidate ? "eager" : "lazy"}
-                  fetchPriority={isLcpCandidate ? "high" : "auto"}
+                  {...lcpImageProps}
                 />
               </figure>
             </Link>

--- a/src/components/UiParts/ImageWithBlur/index.tsx
+++ b/src/components/UiParts/ImageWithBlur/index.tsx
@@ -1,18 +1,33 @@
-import Image from "next/image"
+import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton"
 
 import type { ImageProps } from "next/image"
 
 type ImageWithBlurProps = {
   src: string
   className?: string
+  /**
+   * ImageWithSkeleton の wrapperClassName にそのまま転送される。
+   * ImageWithBlur は（ImageWithSkeleton を直接使う場合と異なり）呼び出し元が
+   * position: relative なコンテナを用意している前提を置かないため、常に
+   * ラッパー span を生成する（wrapperClassName を省略した場合は空文字列扱い）。
+   */
+  wrapperClassName?: string
+  /**
+   * ImageWithSkeleton の skeletonClassName にそのまま転送される。
+   * 円形（rounded-full）画像などスケルトンの見た目を画像に合わせたい場合に指定する。
+   */
+  skeletonClassName?: string
 } & Omit<ImageProps, 'placeholder' | 'blurDataURL' | "src">
 
 // Cloudflare Workersランタイムではfs/sharpが使用不可のため、blurプレースホルダーを省略
-const ImageWithBlur = ({ className = "", src, alt, ...restProps }: ImageWithBlurProps) => {
+// 読み込み完了までは ImageWithSkeleton によるスケルトン表示に委譲する
+const ImageWithBlur = ({ className = "", src, alt, wrapperClassName = "", skeletonClassName, ...restProps }: ImageWithBlurProps) => {
   return (
-    <Image
+    <ImageWithSkeleton
       {...restProps}
       className={className}
+      wrapperClassName={wrapperClassName}
+      skeletonClassName={skeletonClassName}
       src={src}
       alt={alt}
       placeholder="empty"

--- a/src/components/UiParts/ImageWithSkeleton/index.spec.tsx
+++ b/src/components/UiParts/ImageWithSkeleton/index.spec.tsx
@@ -1,0 +1,150 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ImageWithSkeleton from './index';
+
+describe('ImageWithSkeleton', () => {
+  it('初期表示ではスケルトンが表示される（opacity-100 / animate-pulse）', () => {
+    render(
+      <ImageWithSkeleton src="/author.png" alt="テスト画像" width={100} height={100} />
+    );
+
+    const skeleton = screen.getByRole('img', { hidden: true }).nextSibling as HTMLElement;
+    expect(skeleton).toHaveClass('opacity-100');
+    expect(skeleton).toHaveClass('animate-pulse');
+  });
+
+  it('画像のonLoadが発火するとスケルトンがフェードアウトする（opacity-0）', async () => {
+    render(
+      <ImageWithSkeleton src="/author.png" alt="テスト画像" width={100} height={100} />
+    );
+
+    const img = screen.getByRole('img', { hidden: true });
+    fireEvent.load(img);
+
+    // NOTE: next/image の onLoad は img.decode() の Promise 解決を経由して
+    // 非同期に呼ばれるため（node_modules/next/dist/client/image-component.js の
+    // handleLoading 参照）、waitFor でマイクロタスクの解決を待つ必要がある
+    const skeleton = img.nextSibling as HTMLElement;
+    await waitFor(() => {
+      expect(skeleton).toHaveClass('opacity-0');
+    });
+    expect(skeleton).not.toHaveClass('animate-pulse');
+  });
+
+  it('画像のonErrorが発火してもスケルトンは解除される（読み込み中のまま固まらない）', () => {
+    render(
+      <ImageWithSkeleton src="/broken.png" alt="テスト画像" width={100} height={100} />
+    );
+
+    const img = screen.getByRole('img', { hidden: true });
+    fireEvent.error(img);
+
+    const skeleton = img.nextSibling as HTMLElement;
+    expect(skeleton).toHaveClass('opacity-0');
+  });
+
+  it('呼び出し元のonLoad/onErrorも合わせて呼ばれる', async () => {
+    const onLoad = vi.fn();
+    const onError = vi.fn();
+    render(
+      <ImageWithSkeleton
+        src="/author.png"
+        alt="テスト画像"
+        width={100}
+        height={100}
+        onLoad={onLoad}
+        onError={onError}
+      />
+    );
+
+    const img = screen.getByRole('img', { hidden: true });
+    fireEvent.load(img);
+    fireEvent.error(img);
+
+    // onError は同期的に呼ばれるが、onLoad は img.decode() の Promise 経由で非同期に呼ばれる
+    expect(onError).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onLoad).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('wrapperClassName を指定しない場合はラッパー要素を生成しない', () => {
+    const { container } = render(
+      <div className="relative">
+        <ImageWithSkeleton src="/author.png" alt="テスト画像" width={100} height={100} />
+      </div>
+    );
+
+    // ラッパー span が無いので、直下の子は img とスケルトン span の2つのみ
+    expect(container.firstChild?.childNodes).toHaveLength(2);
+  });
+
+  it('wrapperClassName を指定すると relative なラッパー要素が生成される', () => {
+    const { container } = render(
+      <ImageWithSkeleton
+        src="/author.png"
+        alt="テスト画像"
+        width={100}
+        height={100}
+        wrapperClassName="shrink-0"
+      />
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.tagName).toBe('SPAN');
+    expect(wrapper).toHaveClass('relative');
+    expect(wrapper).toHaveClass('inline-block');
+    expect(wrapper).toHaveClass('shrink-0');
+  });
+
+  it('wrapperClassName に空文字列を渡した場合も（undefinedとは異なり）ラッパー要素が生成される', () => {
+    // NOTE: ImageWithBlur のデフォルト値や ThumbnailCard の実際の呼び出しがこの空文字列パターンを使っている。
+    // undefined の場合とは異なる分岐であることを回帰テストとして固定する。
+    const { container } = render(
+      <ImageWithSkeleton src="/author.png" alt="テスト画像" width={100} height={100} wrapperClassName="" />
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.tagName).toBe('SPAN');
+    expect(wrapper).toHaveClass('relative');
+    expect(wrapper).toHaveClass('inline-block');
+  });
+
+  it('skeletonClassName で指定したクラス（角丸など）がスケルトンに適用される', () => {
+    render(
+      <ImageWithSkeleton
+        src="/author.png"
+        alt="テスト画像"
+        width={100}
+        height={100}
+        skeletonClassName="rounded-full"
+      />
+    );
+
+    const skeleton = screen.getByRole('img', { hidden: true }).nextSibling as HTMLElement;
+    expect(skeleton).toHaveClass('rounded-full');
+  });
+
+  it('src が変化すると isLoaded がリセットされ、スケルトンが再表示される', async () => {
+    const { rerender } = render(
+      <ImageWithSkeleton src="/author.png" alt="テスト画像" width={100} height={100} />
+    );
+
+    const img = screen.getByRole('img', { hidden: true });
+    fireEvent.load(img);
+    const skeleton = img.nextSibling as HTMLElement;
+    await waitFor(() => {
+      expect(skeleton).toHaveClass('opacity-0');
+    });
+
+    // 同一インスタンスのまま src だけ差し替える（key変更による再マウントではないケース）
+    rerender(
+      <ImageWithSkeleton src="/other.png" alt="テスト画像" width={100} height={100} />
+    );
+
+    await waitFor(() => {
+      expect(skeleton).toHaveClass('opacity-100');
+      expect(skeleton).toHaveClass('animate-pulse');
+    });
+  });
+});

--- a/src/components/UiParts/ImageWithSkeleton/index.stories.tsx
+++ b/src/components/UiParts/ImageWithSkeleton/index.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ImageWithSkeleton from ".";
+
+const meta = {
+  title: "UiParts/ImageWithSkeleton",
+  component: ImageWithSkeleton,
+  tags: ["autodocs"],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+} satisfies Meta<typeof ImageWithSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// NOTE: Storybook上では実際の読み込み完了イベントが即時発火するため、
+// スケルトンが一瞬で消える見た目になる（本番の低速回線下での見え方を確認する場合はブラウザのネットワークスロットリングを併用すること）
+//
+// NOTE: wrapperClassName を指定しない使い方（ArticleCard/ArticleBody等と同じ）を示すため、
+// 呼び出し側が position: relative なコンテナを用意する契約を decorator で再現している。
+// これが無いとスケルトンの absolute inset-0 が画像サイズを超えて広がってしまう。
+export const Default: Story = {
+  args: {
+    src: "/author.png",
+    alt: "サンプル画像",
+    width: 200,
+    height: 200,
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative inline-block h-[200px] w-[200px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const WithWrapper: Story = {
+  args: {
+    src: "/author.png",
+    alt: "サンプル画像（固定幅のアバター想定）",
+    width: 96,
+    height: 96,
+    className: "aspect-square w-20 rounded-full object-cover shadow-md",
+    wrapperClassName: "shrink-0",
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex w-64 items-center gap-4 border border-dashed border-gray-300 p-4">
+        <Story />
+        <p>横に並ぶテキスト（アバターが縮まないことを確認）</p>
+      </div>
+    ),
+  ],
+};

--- a/src/components/UiParts/ImageWithSkeleton/index.tsx
+++ b/src/components/UiParts/ImageWithSkeleton/index.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Image from "next/image";
+import { cltw } from "@/util";
+
+import type { ImageProps } from "next/image";
+
+type ImageWithSkeletonProps = {
+  /**
+   * スケルトンのスタイルを上書きするクラス名（例: 円形画像には "rounded-full" を渡す）
+   */
+  skeletonClassName?: string;
+  /**
+   * 指定した場合、内部で position: relative な <span> を生成してラップする（inline-block）。
+   * 指定しない場合、呼び出し側が画像とぴったり同じ大きさの position: relative なコンテナを用意すること。
+   */
+  wrapperClassName?: string;
+} & ImageProps;
+
+/**
+ * next/image のロード完了(onLoad)/エラー(onError)までスケルトンを表示するラッパー。
+ * スケルトンは画像の手前に重ねて表示しフェードアウトさせる方式（画像自体のopacityは操作しない）。
+ * これにより priority/preload 指定のLCP対象画像にもスケルトンを適用してよく、LCP計測への悪影響がない。
+ *
+ * 遷移中に画像要素自体がアンマウント→リマウントされるケース（View Transition時の二重フェッチなど）でも、
+ * このコンポーネントごと再マウントされ isLoaded は false から始まり直すため、
+ * 最終的に成功したロードで onLoad が発火するまでスケルトンは表示され続ける。
+ * また、同一インスタンスのまま src だけが差し替わるケース（将来カルーセル等で再利用される場合）に備え、
+ * src の変化を検知して isLoaded を明示的にリセットする。
+ *
+ * 既知の制約: 初回SSR＋ハイドレーション時、ブラウザが画像を実際には表示可能な状態にしていても、
+ * isLoaded は React のハイドレーションが完了し onLoad 相当の処理が走るまで false のままになる。
+ * 通常の環境ではハイドレーションは数百ms以内に完了するため体感できる問題にならないが、
+ * 極端に低スペックな端末やCPUが逼迫した状況ではスケルトンが数秒残る可能性がある。
+ * これは「画像自体のopacityを操作しない（LCP計測に影響しない）」設計とのトレードオフであり、
+ * onLoad/refコールバックのタイミングはNext.js側のハイドレーション完了に依存するため
+ * このコンポーネント内だけでは解消できない（next/imageのownRefコールバックもハイドレーション後にしか走らない）。
+ */
+const ImageWithSkeleton = ({
+  skeletonClassName = "",
+  wrapperClassName,
+  onLoad,
+  onError,
+  alt,
+  src,
+  ...restProps
+}: ImageWithSkeletonProps) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  // src が差し替わった場合（同一インスタンスがキーを変えずに再利用されるケース）に
+  // スケルトンを再表示できるよう、レンダー中に前回の src と比較して isLoaded を調整する
+  // （React公式が推奨する「レンダー中の状態調整」パターン。useEffectだと1フレーム遅れて
+  // 古い画像が一瞬見えてしまうが、この方式なら同じレンダーの中で解消できる）
+  const [prevSrc, setPrevSrc] = useState(src);
+  if (src !== prevSrc) {
+    setPrevSrc(src);
+    setIsLoaded(false);
+  }
+
+  // onLoad/onError の参照を安定させる。ここをレンダーごとに新しいクロージャにすると、
+  // next/image内部の ownRef が依存配列(onError等)の変化を検知してrefを再アタッチし、
+  // 画像読み込み完了後の再レンダー時にも img.src の再代入(エラー検知用ワークアラウンド)が
+  // 再度走ってしまい、無駄な再デコードサイクルが発生するため。
+  const handleLoad = useCallback<NonNullable<ImageProps["onLoad"]>>(
+    (e) => {
+      setIsLoaded(true);
+      onLoad?.(e);
+    },
+    [onLoad]
+  );
+  const handleError = useCallback<NonNullable<ImageProps["onError"]>>(
+    (e) => {
+      // エラー時もスケルトンは解除する（読み込み中のまま固まるのを防ぐ）
+      setIsLoaded(true);
+      onError?.(e);
+    },
+    [onError]
+  );
+
+  const content = (
+    <>
+      <Image
+        {...restProps}
+        src={src}
+        alt={alt}
+        onLoad={handleLoad}
+        onError={handleError}
+      />
+      <span
+        aria-hidden="true"
+        className={cltw(
+          "pointer-events-none absolute inset-0 bg-gray-200 transition-opacity duration-300 dark:bg-gray-600",
+          isLoaded ? "opacity-0" : "animate-pulse opacity-100",
+          skeletonClassName
+        )}
+      />
+    </>
+  );
+
+  if (wrapperClassName === undefined) return content;
+  return (
+    <span className={cltw("relative inline-block", wrapperClassName)}>
+      {content}
+    </span>
+  );
+};
+
+export default ImageWithSkeleton;


### PR DESCRIPTION
## Summary
- サイト遷移直後、画像が読み込まれるまで空白になり読み込み完了と同時に唐突に表示される「チラつき」を解消するため、`next/image` をラップした `ImageWithSkeleton` を新設し、記事一覧サムネイル・記事詳細アイキャッチ・本文中画像・プロフィール/著者アバターの読み込み中にスケルトンを表示するようにしました
- 本番環境でView Transition中の画像アンマウント/リマウントによる二重フェッチを実際に確認したうえで、スケルトンで空白期間を隠す方式を採用しています
- スケルトンは画像の手前に重ねてフェードアウトさせる方式にし、画像自体のopacity操作をやめることでLCP計測への悪影響を回避しました（従来はLCP候補画像だけスケルトンを意図的にスキップしていましたが、この設計変更によりその特例が不要になりました）
- Next.js 16で非推奨の `priority` prop を `preload` に置き換えました
- 円形画像向けの `skeletonClassName`、独自のposition:relativeコンテナを持たない呼び出し元向けの `wrapperClassName` を用意しました
- `onLoad`/`onError` を `useCallback` で安定化し、next/image内部でrefが不要に再アタッチされることによる無駄な再デコードサイクルを回避しました

## Test plan
- [x] `npx tsc --noEmit` — 本体コードはエラーなし（既存のvitestグローバル型の問題は無関係な既知事象）
- [x] `npm run lint` — 0エラー
- [x] `npx vitest run` — 新規9件含め成功（既存の `pagination.spec.tsx` の失敗は変更前から存在する無関係な既存問題であることを `git stash` で確認済み）
- [x] `npm run build` — 135ページ生成成功
- [x] Chrome DevTools MCPでSlow 3G/CPUスロットリング環境下、記事一覧→記事詳細への遷移でスケルトン→フェードインの挙動を実機確認
- [x] 円形アバター（HeroSection/ThumbnailCard/BottomCard）でスケルトンのborder-radiusが画像と一致することを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWi2dr6CBoKg7q8jWK44XD