### PR TITLE
fix: microCMSのcategoriesを唯一の情報源としてカテゴリ管理を動的化

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -82,26 +82,6 @@
     "bannerSubtitle": "Feel free to contact us",
     "bannerCta": "Details"
   },
-  "categories": {
-    "python": "Python",
-    "typescript": "TypeScript",
-    "css": "CSS",
-    "next_js": "Next.js",
-    "release_notes": "Release Notes",
-    "aws": "AWS",
-    "review": "Review",
-    "zakki": "Daily",
-    "react": "React",
-    "openai_api": "OpenAI API",
-    "gadget": "Gadget",
-    "tailwindcss": "TailwindCSS",
-    "ui_parts": "UI",
-    "programming": "Programming",
-    "career": "Career",
-    "life_hack": "LifeHack",
-    "news": "News",
-    "terraform": "Terraform"
-  },
   "about": {
     "pageTitle": "Ryota — Software Engineer / Fullstack",
     "pageDescription": "Fullstack software engineer at a Tokyo-based logistics startup, working across Next.js, TypeScript, and AWS. Writing about the kind of web development problems that don't fit cleanly in tutorials."

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -83,26 +83,6 @@
     "bannerSubtitle": "お気軽にお問い合わせください",
     "bannerCta": "詳細"
   },
-  "categories": {
-    "python": "Python",
-    "typescript": "TypeScript",
-    "css": "CSS",
-    "next_js": "Next.js",
-    "release_notes": "Release Notes",
-    "aws": "AWS",
-    "review": "レビュー",
-    "zakki": "雑記",
-    "react": "React",
-    "openai_api": "OpenAI API",
-    "gadget": "ガジェット",
-    "tailwindcss": "TailwindCSS",
-    "ui_parts": "UI",
-    "programming": "プログラミング",
-    "career": "Career",
-    "life_hack": "LifeHack",
-    "news": "時事",
-    "terraform": "Terraform"
-  },
   "about": {
     "pageTitle": "りょた — Software Engineer / フルスタックエンジニア",
     "pageDescription": "東京の物流スタートアップで、Next.js / TypeScript / AWS を扱うフルスタックエンジニア。教育・SES・物流と3つの業界を渡り歩いてきました。「同じ場所で詰まった人の時間を5分でも短くする」をミッションに、業務で得た知見をブログで発信しています。"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node ./scripts/generate-categories.js",
     "dev": "next dev -p 3006",
+    "prebuild": "node ./scripts/generate-categories.js",
     "build": "next build",
     "analyze": "ANALYZE=true npm run build",
     "start": "next start",
@@ -14,6 +16,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "update-rss": "node ./src/static/rss/rss-parser.js",
+    "generate-categories": "node ./scripts/generate-categories.js",
     "preview:stg": "opennextjs-cloudflare build --config wrangler.stg.jsonc && opennextjs-cloudflare preview --config wrangler.stg.jsonc",
     "preview:prd": "opennextjs-cloudflare build --config wrangler.prd.jsonc && opennextjs-cloudflare preview --config wrangler.prd.jsonc",
     "deploy:stg": "opennextjs-cloudflare build --config wrangler.stg.jsonc && opennextjs-cloudflare deploy --config wrangler.stg.jsonc",

--- a/scripts/generate-categories.js
+++ b/scripts/generate-categories.js
@@ -1,0 +1,87 @@
+// microCMSの「categories」コンテンツを取得し、src/static/categories.generated.ts を書き出す。
+// npm run dev / npm run build の predev / prebuild フックから実行される（package.json参照）。
+//
+// 取得に失敗した場合はファイルを上書きせず終了する（既存ファイル＝前回成功時の内容を維持する）。
+// そのため src/static/categories.generated.ts は git 管理下に置き、CIのLintステップ
+// （MICROCMS_API_KEY を持たず本スクリプトを実行しない）でも常に解決可能な状態を保つ。
+const { writeFileSync } = require("fs");
+const path = require("path");
+const { loadEnvConfig } = require("@next/env");
+const { createClient } = require("microcms-js-sdk");
+
+loadEnvConfig(process.cwd());
+
+const OUTPUT_PATH = path.join(__dirname, "../src/static/categories.generated.ts");
+
+// microCMSのcontent idと、過去に公開しインデックスされたURLスラッグが異なる例外のみ列挙する。
+// 新規カテゴリ追加時にここへの追記は基本的に不要（content id をそのままスラッグとして使う）。
+const CATEGORY_SLUG_OVERRIDES = {
+  "ui-parts": "ui_parts",
+};
+
+// microCMSが無応答の場合にnpm run dev/buildが無期限にハングするのを防ぐための上限（ミリ秒）
+const FETCH_TIMEOUT_MS = 15_000;
+
+const FILE_HEADER = `// このファイルは \`node scripts/generate-categories.js\` によって自動生成されます。
+// 手動で編集しないでください（次回の npm run dev / npm run build で上書きされます）。
+// microCMSの「categories」コンテンツが唯一の情報源です。
+
+export type CategoryEntry = {
+  id: string;
+  slug: string;
+  name: string;
+  name_en: string;
+};
+
+`;
+
+function toFileContent(entries) {
+  const body = entries
+    .map(
+      (entry) =>
+        `  { id: ${JSON.stringify(entry.id)}, slug: ${JSON.stringify(entry.slug)}, name: ${JSON.stringify(entry.name)}, name_en: ${JSON.stringify(entry.name_en)} },`,
+    )
+    .join("\n");
+  return `${FILE_HEADER}export const CATEGORIES: CategoryEntry[] = [\n${body}\n];\n`;
+}
+
+async function fetchCategoryEntries() {
+  const serviceDomain = process.env.MICROCMS_SERVICE_DOMAIN;
+  const apiKey = process.env.MICROCMS_API_KEY;
+
+  if (!serviceDomain || !apiKey) {
+    throw new Error("MICROCMS_SERVICE_DOMAIN / MICROCMS_API_KEY が設定されていません");
+  }
+
+  const client = createClient({ serviceDomain, apiKey });
+  // getAllContents は limit=100 固定 + offset ページネーションで全件を自動取得する
+  const categories = await client.getAllContents({
+    endpoint: "categories",
+    queries: { fields: "id,name,name_en", orders: "createdAt" },
+    customRequestInit: { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+  });
+
+  if (categories.length === 0) {
+    throw new Error("microCMSから取得したカテゴリが0件でした");
+  }
+
+  return categories.map((category) => ({
+    id: category.id,
+    slug: CATEGORY_SLUG_OVERRIDES[category.id] || category.id,
+    name: category.name,
+    name_en: category.name_en || category.name,
+  }));
+}
+
+(async () => {
+  try {
+    const entries = await fetchCategoryEntries();
+    writeFileSync(OUTPUT_PATH, toFileContent(entries));
+    console.log(`[generate-categories] microCMSから${entries.length}件のカテゴリを取得し、生成しました。`);
+  } catch (error) {
+    console.warn(
+      "[generate-categories] microCMSからの取得に失敗しました。既存の src/static/categories.generated.ts をそのまま使用します。",
+      error,
+    );
+  }
+})();

--- a/src/app/[locale]/blogs/[category]/opengraph-image.tsx
+++ b/src/app/[locale]/blogs/[category]/opengraph-image.tsx
@@ -1,7 +1,8 @@
 import { ImageResponse } from "next/og";
 
-import { AUTHOR_NAME, AUTHOR_NAME_EN, CATEGORY_MAPED_NAME } from "@/static/blogs";
-import { getCategoryById } from "@/lib/microcms";
+import { AUTHOR_NAME, AUTHOR_NAME_EN } from "@/static/blogs";
+import { findCategoryBySlug } from "@/static/categories";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
 
 export const size = {
   width: 1200,
@@ -28,16 +29,8 @@ export default async function Image({ params }: { params: Promise<{ locale: stri
   // localeに基づいて作者名を選択
   const authorName = locale === 'en' ? AUTHOR_NAME_EN : AUTHOR_NAME;
 
-  let categoryName = category;
-
-  try {
-    const categoryData = await getCategoryById(category);
-    // localeに基づいてカテゴリー名を選択
-    categoryName = locale === 'en' && categoryData.name_en ? categoryData.name_en : categoryData.name;
-  } catch (error) {
-    // microCMSから取得できない場合は、CATEGORY_MAPED_NAMEから取得
-    categoryName = CATEGORY_MAPED_NAME[category] || category;
-  }
+  const categoryEntry = findCategoryBySlug(category);
+  const categoryName = categoryEntry ? getLocalizedCategoryName(categoryEntry, locale) : category;
   
   return new ImageResponse(
     (

--- a/src/app/[locale]/blogs/[category]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page.tsx
@@ -10,19 +10,20 @@ import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
 import ZennArticleList from "@/components/ZennArticleList";
 import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
-import { BLOG_TYPE_QUERY, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY, CATEGORY_MAPED_NAME, CATEGORY_MAPED_ID } from "@/static/blogs";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
+import { BLOG_TYPE_QUERY, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY } from "@/static/blogs";
+import { CATEGORIES, findCategoryBySlug } from "@/static/categories";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
-import type { MappedKeyLiteralType } from "@/types/microcms";
 import type { BlogTypeKeyLIteralType } from "@/types";
 import { locales } from '@/i18n/config';
 
 export async function generateStaticParams() {
   const params = [];
   for (const locale of locales) {
-    for (const categoryId of Object.values(CATEGORY_MAPED_ID)) {
+    for (const category of CATEGORIES) {
       params.push({
         locale,
-        category: categoryId
+        category: category.slug
       });
     }
   }
@@ -36,22 +37,13 @@ export async function generateMetadata(
   const { locale, category } = await params;
   const resolvedSearchParams = await searchParams;
   const t = await getTranslations({ locale, namespace: 'blog' });
-  const tCategories = await getTranslations({ locale, namespace: 'categories' });
-  const categoryName = CATEGORY_MAPED_NAME[category];
-  
-  if (!categoryName) {
+  const categoryEntry = findCategoryBySlug(category);
+
+  if (!categoryEntry) {
     notFound();
   }
-  
-  // カテゴリ名を翻訳
-  let translatedCategoryName;
-  try {
-    // TypeScriptエラーを回避するために型アサーション
-    translatedCategoryName = (tCategories as any)(category);
-  } catch {
-    // 翻訳が見つからない場合は元の値を使用
-    translatedCategoryName = categoryName;
-  }
+
+  const translatedCategoryName = getLocalizedCategoryName(categoryEntry, locale);
 
   const blogType = resolvedSearchParams.blogType || "blogs";
   const page = resolvedSearchParams.page || null;
@@ -117,9 +109,9 @@ const Page = async ({ params, searchParams }: PageProps) => {
   // Next.js 16では、paramsとsearchParamsを非同期で取得する必要がある
   const { locale, category } = await params;
   const resolvedSearchParams = await searchParams;
-  const categoryName = CATEGORY_MAPED_NAME[category];
+  const categoryEntry = findCategoryBySlug(category);
 
-  if (!categoryName) {
+  if (!categoryEntry) {
     notFound();
   }
 
@@ -129,7 +121,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
 
   const modifiedSearchParams = {
     ...resolvedSearchParams,
-    [CATEGORY_QUERY]: categoryName
+    [CATEGORY_QUERY]: categoryEntry.id
   };
 
   const query: MicroCMSQueries = generateQuery(modifiedSearchParams);
@@ -142,7 +134,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
             <div className="flex justify-center items-center p-3 bg-white dark:bg-black border-2 border-gray-200 dark:border-gray-600">
               <BlogTypeTabs blogType={blogType} />
             </div>
-            <SearchStateCard category={categoryName} keyword={keyword} />
+            <SearchStateCard category={getLocalizedCategoryName(categoryEntry, locale)} keyword={keyword} />
           </div>
           {blogType === "zenn"
             ?

--- a/src/app/[locale]/blogs/[category]/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page/[page]/page.tsx
@@ -9,41 +9,43 @@ import Skelton from "@/components/ArticleList/skelton";
 import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
 import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
 import { getBlogListByLocale } from "@/lib/microcms";
-import { PER_PAGE, CATEGORY_MAPED_NAME, CATEGORY_MAPED_ID } from "@/static/blogs";
+import { PER_PAGE } from "@/static/blogs";
+import { CATEGORIES, findCategoryBySlug } from "@/static/categories";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
 import { locales } from '@/i18n/config';
 
 export async function generateStaticParams() {
-  const categories = Object.entries(CATEGORY_MAPED_ID);
-  const staticParams = [];
-  
-  for (const locale of locales) {
-    for (const [categoryName, categoryId] of categories) {
+  // ロケール×カテゴリの組み合わせを並列フェッチする（sitemap.tsのcategoryTotalsと同じ方針。
+  // 直列await(for-of内)だとカテゴリ数×ロケール数分のリクエストがビルド時間に積み上がるため）
+  const combinations = locales.flatMap((locale) => CATEGORIES.map((category) => ({ locale, category })));
+
+  const totalPagesByCombination = await Promise.all(
+    combinations.map(async ({ locale, category }) => {
       try {
         const query: MicroCMSQueries = {
           limit: 1,
-          filters: `category[contains]${categoryId}`
+          filters: `category[contains]${category.id}`
         };
-        
+
         const data = await getBlogListByLocale(locale, query);
-        const totalPages = Math.ceil(data.totalCount / PER_PAGE);
-        
-        // ページ2以降のパラメータを生成（ページ1は /blogs/[category] にある）
-        for (let i = 2; i <= totalPages; i++) {
-          staticParams.push({
-            locale,
-            category: categoryId,
-            page: String(i)
-          });
-        }
+        return { locale, category, totalPages: Math.ceil(data.totalCount / PER_PAGE) };
       } catch (error) {
-        console.warn(`カテゴリの静的パラメータ生成に失敗しました: ${categoryName}`, error);
+        console.warn(`カテゴリの静的パラメータ生成に失敗しました: ${category.name}`, error);
+        return { locale, category, totalPages: 0 };
       }
-    }
-  }
-  
-  return staticParams;
+    })
+  );
+
+  return totalPagesByCombination.flatMap(({ locale, category, totalPages }) =>
+    // ページ2以降のパラメータを生成（ページ1は /blogs/[category] にある）
+    Array.from({ length: Math.max(totalPages - 1, 0) }, (_, i) => ({
+      locale,
+      category: category.slug,
+      page: String(i + 2)
+    }))
+  );
 }
 
 export async function generateMetadata(
@@ -52,22 +54,13 @@ export async function generateMetadata(
   // Next.js 16では、paramsを非同期で取得する必要がある
   const { locale, category, page } = await params;
   const t = await getTranslations({ locale, namespace: 'blog' });
-  const tCategories = await getTranslations({ locale, namespace: 'categories' });
-  const categoryName = CATEGORY_MAPED_NAME[category];
-  
-  if (!categoryName) {
+  const categoryEntry = findCategoryBySlug(category);
+
+  if (!categoryEntry) {
     notFound();
   }
-  
-  // カテゴリ名を翻訳
-  let translatedCategoryName;
-  try {
-    // TypeScriptエラーを回避するために型アサーション
-    translatedCategoryName = (tCategories as any)(category);
-  } catch {
-    // 翻訳が見つからない場合は元の値を使用
-    translatedCategoryName = categoryName;
-  }
+
+  const translatedCategoryName = getLocalizedCategoryName(categoryEntry, locale);
 
   const pageUrl = buildPageUrl(locale, "blogs", category, "page", page);
   const title = `${translatedCategoryName} - ${t('page')} ${page}`;
@@ -95,10 +88,10 @@ type PageProps = {
 const Page = async ({ params }: PageProps) => {
   // Next.js 16では、paramsを非同期で取得する必要がある
   const { locale, category, page } = await params;
-  const categoryName = CATEGORY_MAPED_NAME[category];
+  const categoryEntry = findCategoryBySlug(category);
   const pageNum = parseInt(page);
 
-  if (!categoryName) {
+  if (!categoryEntry) {
     notFound();
   }
 
@@ -107,10 +100,10 @@ const Page = async ({ params }: PageProps) => {
     notFound();
   }
 
-  // このカテゴリでページが存在するかチェック
+  // このカテゴリでページが存在するかチェック（microCMSへのフィルタは必ずcontent idを使う）
   const checkQuery: MicroCMSQueries = {
     limit: 1,
-    filters: `category[contains]${category}`
+    filters: `category[contains]${categoryEntry.id}`
   };
   const data = await getBlogListByLocale(locale, checkQuery);
   const totalPages = Math.ceil(data.totalCount / PER_PAGE);
@@ -122,7 +115,7 @@ const Page = async ({ params }: PageProps) => {
   const blogType = "blogs";
   const query: MicroCMSQueries = generateQuery({
     page,
-    category,
+    category: categoryEntry.id,
     keyword: ""
   });
 
@@ -136,7 +129,7 @@ const Page = async ({ params }: PageProps) => {
                 <BlogTypeTabs blogType={blogType} />
               </Suspense>
             </div>
-            <SearchStateCard category={categoryName} keyword={""} />
+            <SearchStateCard category={getLocalizedCategoryName(categoryEntry, locale)} keyword={""} />
           </div>
           <Suspense fallback={<Skelton />}>
             <ArticleList

--- a/src/app/[locale]/blogs/page.tsx
+++ b/src/app/[locale]/blogs/page.tsx
@@ -9,15 +9,15 @@ import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
 import ZennArticleList from "@/components/ZennArticleList";
 import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
 import {
   BLOG_TYPE_QUERY,
   CATEGORY_QUERY,
   KEYWORD_QUERY,
   PAGE_QUERY,
-  CATEGORY_MAPED_ID,
 } from "@/static/blogs";
+import { resolveCategoryEntry } from "@/static/categories";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
-import type { MappedKeyLiteralType } from "@/types/microcms";
 import type { BlogTypeKeyLIteralType } from "@/types";
 
 // キャッシュ設定: 1時間のISR
@@ -30,7 +30,7 @@ interface PageProps {
   searchParams: Promise<{
     [BLOG_TYPE_QUERY]: BlogTypeKeyLIteralType;
     [PAGE_QUERY]: string;
-    [CATEGORY_QUERY]: MappedKeyLiteralType;
+    [CATEGORY_QUERY]: string;
     [KEYWORD_QUERY]: string;
   }>;
 }
@@ -44,10 +44,6 @@ export async function generateMetadata({
   const resolvedSearchParams = await searchParams;
   const t = await getTranslations({ locale, namespace: "blog" });
   const tMeta = await getTranslations({ locale, namespace: "metadata" });
-  const tCategories = await getTranslations({
-    locale,
-    namespace: "categories",
-  });
   const blogType = resolvedSearchParams.blogType || "blogs";
   const page = resolvedSearchParams.page || null;
   const category = resolvedSearchParams.category || null;
@@ -84,19 +80,11 @@ export async function generateMetadata({
   let title = page ? ` - ${t("page")} ${page}` : "";
   let description = "";
 
-  // カテゴリ名を翻訳
+  // カテゴリ名を翻訳（id・スラッグ・表示名(ja/en)のいずれで渡されても解決する）
   let translatedCategory = category;
   if (category) {
-    // カテゴリ名からIDを取得（CATEGORY_MAPED_NAMEから渡される場合を考慮）
-    const categoryId =
-      CATEGORY_MAPED_ID[category as keyof typeof CATEGORY_MAPED_ID] || category;
-    try {
-      // TypeScriptエラーを回避するために型アサーション
-      translatedCategory = (tCategories as any)(categoryId);
-    } catch {
-      // 翻訳が見つからない場合は元の値を使用
-      translatedCategory = category;
-    }
+    const categoryEntry = resolveCategoryEntry(category);
+    translatedCategory = categoryEntry ? getLocalizedCategoryName(categoryEntry, locale) : category;
   }
 
   // NOTE: ?category=hoge&keyword=fuga にアクセスした場合
@@ -135,6 +123,8 @@ const Page = async ({ params, searchParams }: PageProps) => {
   const page = resolvedSearchParams[PAGE_QUERY] || "1";
 
   const query: MicroCMSQueries = generateQuery(resolvedSearchParams);
+  const categoryEntry = category ? resolveCategoryEntry(category) : undefined;
+  const categoryLabel = categoryEntry ? getLocalizedCategoryName(categoryEntry, locale) : category;
 
   return (
     <>
@@ -145,7 +135,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
               <BlogTypeTabs blogType={blogType} />
             </div>
             {(category || keyword) && (
-              <SearchStateCard category={category} keyword={keyword} />
+              <SearchStateCard category={categoryLabel} keyword={keyword} />
             )}
           </div>
           {blogType === "zenn" ? (

--- a/src/app/[locale]/docs/llms.txt/route.ts
+++ b/src/app/[locale]/docs/llms.txt/route.ts
@@ -10,6 +10,7 @@ import {
   SITE_TITLE,
 } from "@/static/blogs";
 import { getPrimaryCategoryId } from "@/lib";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
 import { getTranslations } from 'next-intl/server';
 
 // 日付フォーマットの国際化 API
@@ -108,24 +109,10 @@ async function generateCategoriesSection(
     return `${headerText}\n\n${noDataText}`;
   }
 
-  // 翻訳を取得
-  const tCategories = await getTranslations({ locale, namespace: 'categories' });
-
-  // カテゴリ名を取得（英語の場合は翻訳システムを使用）
-  const categoryList = categories.map(({ id, name, name_en }) => {
-    let displayName: string;
-    if (locale === 'en') {
-      // 英語の場合は翻訳システムを使用、フォールバックでname_enまたはname
-      try {
-        displayName = tCategories(id);
-      } catch {
-        displayName = name_en || name;
-      }
-    } else {
-      displayName = name;
-    }
-    return `- ${displayName}`;
-  }).join("\n");
+  // カテゴリ名はmicroCMSの name / name_en を正として使う
+  const categoryList = categories
+    .map((category) => `- ${getLocalizedCategoryName(category, locale)}`)
+    .join("\n");
 
   return `${headerText}\n\n${categoryList}`;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,7 +3,8 @@ import { MetadataRoute } from "next";
 import { baseURL } from "@/config";
 import { getAllBlogList, getBlogList } from "@/lib/microcms";
 import { getPrimaryCategoryId, generateQuery } from "@/lib";
-import { CATEGORY_MAPED_ID, PER_PAGE } from "@/static/blogs";
+import { PER_PAGE } from "@/static/blogs";
+import { CATEGORIES } from "@/static/categories";
 import { SUPPORTED_LOCALES } from "@/types/locale";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
@@ -21,10 +22,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ])
 
     // カテゴリページのパスの多言語対応
-    const categoryPaths = SUPPORTED_LOCALES.flatMap(locale => 
-      Object.values(CATEGORY_MAPED_ID).map((categoryId) => {
+    const categoryPaths = SUPPORTED_LOCALES.flatMap(locale =>
+      CATEGORIES.map((category) => {
         return {
-          url: `${baseURL}/${locale}/blogs/${categoryId}`,
+          url: `${baseURL}/${locale}/blogs/${category.slug}`,
           lastModified: new Date()
         }
       })
@@ -69,23 +70,23 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // NOTE: カテゴリごとの件数取得はロケール非依存（blogsエンドポイント）なので、
     //       カテゴリ単位で1回だけ並列フェッチし、両ロケールのURL生成に使い回す
     const categoryTotals = await Promise.all(
-      Object.entries(CATEGORY_MAPED_ID).map(async ([categoryName, categoryId]) => {
+      CATEGORIES.map(async (category) => {
         try {
-          const query = generateQuery({ page: "1", category: categoryName, keyword: "" });
+          const query = generateQuery({ page: "1", category: category.id, keyword: "" });
           const categoryData = await getBlogList({ ...query, fields: "id" });
-          return { categoryId, totalPages: Math.ceil(categoryData.totalCount / PER_PAGE) };
+          return { categorySlug: category.slug, totalPages: Math.ceil(categoryData.totalCount / PER_PAGE) };
         } catch (error) {
-          console.warn(`カテゴリのサイトマップ生成に失敗しました: ${categoryName}`, error);
-          return { categoryId, totalPages: 0 };
+          console.warn(`カテゴリのサイトマップ生成に失敗しました: ${category.name}`, error);
+          return { categorySlug: category.slug, totalPages: 0 };
         }
       })
     );
 
     const categoryPaginationPaths = SUPPORTED_LOCALES.flatMap((locale) =>
-      categoryTotals.flatMap(({ categoryId, totalPages }) =>
+      categoryTotals.flatMap(({ categorySlug, totalPages }) =>
         // ページ2以降を生成（ページ1は /[locale]/blogs/[category] にある）
         Array.from({ length: Math.max(totalPages - 1, 0) }, (_, i) => ({
-          url: `${baseURL}/${locale}/blogs/${categoryId}/page/${i + 2}`,
+          url: `${baseURL}/${locale}/blogs/${categorySlug}/page/${i + 2}`,
           lastModified: new Date()
         }))
       )

--- a/src/components/ArticleBody/CategoryTag.tsx
+++ b/src/components/ArticleBody/CategoryTag.tsx
@@ -1,26 +1,26 @@
 'use client';
 
 import { Link } from 'next-view-transitions';
-import { useLocale, useTranslations } from 'next-intl';
+import { useLocale } from 'next-intl';
 import Chip from '@/components/UiParts/Chip';
-import { CATEGORY_MAPED_ID } from '@/static/blogs';
+import { getLocalizedCategoryName } from '@/lib/i18n-utils';
+import { resolveCategoryOrDefault } from '@/static/categories';
 
 type CategoryTagProps = {
-  name: string;
+  id: string;
   index: number;
 };
 
-const CategoryTag = ({ name, index }: CategoryTagProps) => {
+const CategoryTag = ({ id, index }: CategoryTagProps) => {
   const locale = useLocale();
-  const t = useTranslations('categories');
-  
-  // カテゴリ名から対応するIDを取得
-  const categoryId = CATEGORY_MAPED_ID[name as keyof typeof CATEGORY_MAPED_ID] || 'programming';
-  const localizedName = t(categoryId);
-  
+
+  const categoryEntry = resolveCategoryOrDefault(id);
+  const categorySlug = categoryEntry.slug;
+  const localizedName = getLocalizedCategoryName(categoryEntry, locale);
+
   return (
     <li key={index} className="block cursor-pointer">
-      <Link href={`/${locale}/blogs/${categoryId}`}> 
+      <Link href={`/${locale}/blogs/${categorySlug}`}>
         <Chip label={`#${localizedName}`} classes="bg-gray-200 dark:bg-gray-600 dark:text-gray-300 px-3 py-2 text-sm text-txt-base hover:opacity-60" />
       </Link>
     </li>

--- a/src/components/ArticleBody/index.tsx
+++ b/src/components/ArticleBody/index.tsx
@@ -68,8 +68,8 @@ const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
         </aside>
       )}
       <ul className='mt-4 flex flex-wrap gap-2'>
-        {data.category.map(({ name }, index) => (
-          <CategoryTag key={index} name={name} index={index} />
+        {data.category.map(({ id }, index) => (
+          <CategoryTag key={index} id={id} index={index} />
         ))}
       </ul>
       <div className="mt-4">

--- a/src/components/CategoryList/index.tsx
+++ b/src/components/CategoryList/index.tsx
@@ -1,19 +1,19 @@
 import { getTranslations } from 'next-intl/server';
 import CategoryItem from "@/components/CategoryList/CategoryItem";
-import { CATEGORY_MAPED_ID } from "@/static/blogs";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
+import { CATEGORIES } from "@/static/categories";
 
 type CategoryListProps = {
   locale: string;
 }
 
 const CategoryList = async ({ locale }: CategoryListProps) => {
-  const t = await getTranslations({ locale, namespace: 'categories' });
   const tBlog = await getTranslations({ locale, namespace: 'blog' });
-  
-  // カテゴリ配列を翻訳データで生成
-  const categoryArray = Object.entries(CATEGORY_MAPED_ID).map(([_, id]) => ({
-    id,
-    name: t(id)
+
+  // カテゴリ配列をmicroCMSのcategoriesコンテンツから生成
+  const categoryArray = CATEGORIES.map((category) => ({
+    id: category.slug,
+    name: getLocalizedCategoryName(category, locale)
   }));
 
   return (

--- a/src/components/Head/JsonLD/index.tsx
+++ b/src/components/Head/JsonLD/index.tsx
@@ -1,7 +1,9 @@
 import type { BreadcrumbList, BlogPosting, WithContext, WebSite } from "schema-dts"
 import type { BlogsContentType } from "@/types/microcms"
-import { SITE_TITLE, CATEGORY_MAPED_NAME } from "@/static/blogs"
+import { SITE_TITLE } from "@/static/blogs"
+import { findCategoryBySlug } from "@/static/categories"
 import { getPrimaryCategoryId, buildPageUrl } from "@/lib"
+import { getLocalizedCategoryName } from "@/lib/i18n-utils"
 
 
 type JsonLDProps = {
@@ -11,7 +13,8 @@ type JsonLDProps = {
 
 const JsonLD = ({ data, locale }: JsonLDProps) => {
   const categoryId = getPrimaryCategoryId(data);
-  const categoryName = CATEGORY_MAPED_NAME[categoryId];
+  const categoryEntry = findCategoryBySlug(categoryId);
+  const categoryName = categoryEntry ? getLocalizedCategoryName(categoryEntry, locale) : categoryId;
   // 構造化データのURLは実ルーティング（/[locale]/blogs/...）に合わせて locale 込みで構築する
   const articleUrl = buildPageUrl(locale, "blogs", categoryId, data.id);
   const authorUrl = buildPageUrl(locale, "about");

--- a/src/components/Pagination/PaginationItem/index.tsx
+++ b/src/components/Pagination/PaginationItem/index.tsx
@@ -3,7 +3,6 @@ import { cltw } from "@/util"
 import { Link } from "next-view-transitions"
 import { useRouter, useSearchParams, usePathname } from "next/navigation"
 import { ReactNode, useCallback } from "react"
-import { CATEGORY_MAPED_ID } from "@/static/blogs"
 
 type PaginationItemProps = {
   currentPage: number

--- a/src/components/RelatedContentList/RelatedContentItem/index.tsx
+++ b/src/components/RelatedContentList/RelatedContentItem/index.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import Chip from "@/components/UiParts/Chip";
-import { CATEGORY_MAPED_NAME } from "@/static/blogs";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
+import { resolveCategoryOrDefault } from "@/static/categories";
 import { CategoriesContentType } from "@/types/microcms";
 import { Link } from "next-view-transitions";
-import { useLocale, useTranslations } from 'next-intl';
+import { useLocale } from 'next-intl';
 
 type RelatedContentItemProps = {
   id: string;
@@ -16,10 +17,9 @@ type RelatedContentItemProps = {
 
 const RelatedContentItem = ({ id, publishedAt, updatedAt, title, category }: RelatedContentItemProps) => {
   const locale = useLocale();
-  const t = useTranslations('categories');
   const displayTime = publishedAt || updatedAt;
-  const primaryCategoryId = category.length > 0 ? category[0].id : "programming";
-  
+  const primaryCategoryId = resolveCategoryOrDefault(category[0]?.id).slug;
+
   return (
     <li>
       <Link href={`/${locale}/blogs/${primaryCategoryId}/${id}`} key={id} className="group transition-opacity hover:opacity-60 flex md:justify-between flex-col gap-1 md:gap-0 md:flex-row items-center py-2">
@@ -28,11 +28,14 @@ const RelatedContentItem = ({ id, publishedAt, updatedAt, title, category }: Rel
           <p className="line-clamp-2 md:line-clamp-3 text-txt-base dark:text-gray-300 group-hover:underline group-hover:underline-offset-4 group-hover:decoration-txt-base dark:group-hover:decoration-gray-300">{title}</p>
         </div>
         <ul className="flex flex-wrap items-center gap-1 w-full md:w-auto justify-end">
-          {category.map(({ id }) => (
-            <li key={id}>
-              <Chip label={t(id)} classes="bg-gray-300 dark:bg-gray-600 dark:text-gray-300 px-2 py-0.5 text-xs text-txt-base" />
-            </li>
-          ))}
+          {category.map(({ id: categoryId }) => {
+            const entry = resolveCategoryOrDefault(categoryId);
+            return (
+              <li key={categoryId}>
+                <Chip label={getLocalizedCategoryName(entry, locale)} classes="bg-gray-300 dark:bg-gray-600 dark:text-gray-300 px-2 py-0.5 text-xs text-txt-base" />
+              </li>
+            );
+          })}
         </ul>
       </Link>
     </li>

--- a/src/components/SearchStateCard/index.tsx
+++ b/src/components/SearchStateCard/index.tsx
@@ -3,8 +3,6 @@
 import { Link } from 'next-view-transitions';
 import { useLocale, useTranslations } from 'next-intl';
 import Chip from "@/components/UiParts/Chip";
-import type { MappedKeyLiteralType } from "@/types/microcms";
-import { CATEGORY_MAPED_ID } from "@/static/blogs";
 
 type SearchStateCardProps = {
   /**
@@ -12,9 +10,9 @@ type SearchStateCardProps = {
    */
   keyword?: string;
   /**
-   * カテゴリー
+   * カテゴリーの表示ラベル（呼び出し元で解決済みのものを渡す）
    */
-  category?: MappedKeyLiteralType | string
+  category?: string
   /**
    * ブログタイプ (Zennモード時の色変更用)
    */
@@ -24,21 +22,6 @@ type SearchStateCardProps = {
 const SearchStateCard = ({ keyword, category, blogType = "blogs" }: SearchStateCardProps) => {
   const locale = useLocale();
   const t = useTranslations('blog');
-  const tCategories = useTranslations('categories');
-
-  // カテゴリ表示名を取得
-  const getCategoryLabel = (categoryValue: string) => {
-    // カテゴリ名からIDを取得（CATEGORY_MAPED_NAMEから渡される場合）
-    const categoryId = CATEGORY_MAPED_ID[categoryValue as keyof typeof CATEGORY_MAPED_ID] || categoryValue;
-
-    // カテゴリIDが翻訳キーとして存在する場合は翻訳を使用
-    try {
-      return tCategories(categoryId as any);
-    } catch {
-      // 翻訳が見つからない場合は元の値を返す
-      return categoryValue;
-    }
-  };
 
   // Zennモード時の色設定とリンク先
   const isZennMode = blogType === "zenn"
@@ -60,7 +43,7 @@ const SearchStateCard = ({ keyword, category, blogType = "blogs" }: SearchStateC
         <ul className="flex gap-4 items-center">
           {category && (
             <li data-testid="pw-search-chip-category">
-              <Chip classes=" text-xs lg:text-md bg-base-color dark:bg-primary px-3 py-2 text-sm text-txt-base dark:text-white" label={getCategoryLabel(category)} />
+              <Chip classes=" text-xs lg:text-md bg-base-color dark:bg-primary px-3 py-2 text-sm text-txt-base dark:text-white" label={category} />
             </li>
           )}
           {keyword && (

--- a/src/lib/i18n-utils.ts
+++ b/src/lib/i18n-utils.ts
@@ -2,7 +2,10 @@
  * i18n関連のユーティリティ関数
  */
 
-import type { CategoriesContentType } from "@/types/microcms";
+type LocalizableCategory = {
+  name: string;
+  name_en?: string;
+};
 
 /**
  * 現在のパスから別のlocaleのパスを生成
@@ -81,7 +84,7 @@ export function getCategoryPaginationPath(locale: string, categoryId: string, pa
 /**
  * ロケールに応じたカテゴリ名を取得
  */
-export function getLocalizedCategoryName(category: CategoriesContentType, locale: string): string {
+export function getLocalizedCategoryName(category: LocalizableCategory, locale: string): string {
   // 英語ロケールでname_enが存在する場合はそれを使用
   if (locale === 'en' && category.name_en) {
     return category.name_en;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,8 +2,10 @@ import type { MicroCMSQueries } from "microcms-js-sdk";
 import { getTranslations } from 'next-intl/server';
 
 import type { BreadcrumbItemType, TOCAssetsType } from "@/types";
-import { CATEGORY_MAPED_ID, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY, PER_PAGE, CATEGORY_MAPED_NAME } from "@/static/blogs";
-import type { MappedKeyLiteralType, BlogsContentType } from "@/types/microcms";
+import { CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY, PER_PAGE } from "@/static/blogs";
+import { resolveCategoryEntry, resolveCategoryOrDefault } from "@/static/categories";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
+import type { BlogsContentType } from "@/types/microcms";
 import { baseURL } from "@/config";
 import { locales } from "@/i18n/config";
 
@@ -36,7 +38,7 @@ export const generateTOCAssets = (html: string) => {
   return results;
 }
 
-export const generateQuery = (searchParams: { [PAGE_QUERY]: string, [CATEGORY_QUERY]: MappedKeyLiteralType | string, [KEYWORD_QUERY]: string }) => {
+export const generateQuery = (searchParams: { [PAGE_QUERY]: string, [CATEGORY_QUERY]: string, [KEYWORD_QUERY]: string }) => {
   let filters = "";
   const query: MicroCMSQueries = { limit: PER_PAGE, offset: 0 }
 
@@ -49,11 +51,9 @@ export const generateQuery = (searchParams: { [PAGE_QUERY]: string, [CATEGORY_QU
   // filters
   if (searchParams[CATEGORY_QUERY]) {
     const categoryValue = searchParams[CATEGORY_QUERY];
-    // If categoryValue is already a category name, use it directly
-    // If it's a category ID, convert it to name using CATEGORY_MAPED_NAME
-    const categoryId = typeof categoryValue === 'string' && CATEGORY_MAPED_ID[categoryValue as keyof typeof CATEGORY_MAPED_ID] 
-      ? CATEGORY_MAPED_ID[categoryValue as keyof typeof CATEGORY_MAPED_ID]
-      : categoryValue;
+    // カテゴリの表示名(ja/en)・URLスラッグ・content idのいずれで渡されてもmicroCMSのcontent idに解決する
+    const categoryEntry = resolveCategoryEntry(categoryValue);
+    const categoryId = categoryEntry?.id ?? categoryValue;
     filters += `${CATEGORY_QUERY}[contains]${categoryId}`;
   }
 
@@ -64,18 +64,19 @@ export const generateQuery = (searchParams: { [PAGE_QUERY]: string, [CATEGORY_QU
   return { ...query, filters };
 }
 
+// 記事のプライマリカテゴリのURLスラッグを返す。該当カテゴリがcategories.generated.tsに
+// 見つからない場合（CMS側での削除等）は必ずDEFAULT_CATEGORY_IDにフォールバックする
+// （CategoryTag/RelatedContentItemと同じresolveCategoryOrDefaultを使うことで挙動を統一する）。
 export const getPrimaryCategoryId = (blog: Pick<BlogsContentType, "category">): string => {
-  if (blog.category.length === 0) return "programming";
-  const categoryName = blog.category[0].name as keyof typeof CATEGORY_MAPED_ID;
-  return CATEGORY_MAPED_ID[categoryName] || "programming";
+  return resolveCategoryOrDefault(blog.category[0]?.id).slug;
 }
 
 export const generateBreadcrumbAssets = async (blog: BlogsContentType, locale: string = 'ja'): Promise<BreadcrumbItemType[]> => {
-  const categoryId = getPrimaryCategoryId(blog);
+  const categoryEntry = resolveCategoryOrDefault(blog.category[0]?.id);
+  const categoryId = categoryEntry.slug;
   const t = await getTranslations({ locale, namespace: 'navigation' });
-  const tCategories = await getTranslations({ locale, namespace: 'categories' });
-  
-  const categoryName = tCategories(categoryId);
+
+  const categoryName = getLocalizedCategoryName(categoryEntry, locale);
   const localePrefix = `/${locale}`;
   
   const results = [

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -66,14 +66,6 @@ export const getAllCategoryList = async (querys?: MicroCMSQueries, customRequest
   return data;
 }
 
-export const getCategoryById = (contentId: string, querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) =>
-  MicroCMSApiGetSingleObjectHandler<CategoriesContentType>(
-    "categories",
-    querys,
-    customRequestInit,
-    contentId,
-  );
-
 
 // English blog functions
 export const getBlogListEn = (querys?: MicroCMSQueries, customRequestInit?: CustomRequestInit) =>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,17 +6,19 @@ import { routing } from './i18n/routing';
 import { getBlogByIdByLocale } from './lib/microcms'
 import { getPrimaryCategoryId } from './lib/index'
 import { LOCALE_COOKIE_NAME } from './types/locale'
-import { CATEGORY_MAPED_ID } from './static/blogs'
+import { CATEGORIES } from './static/categories'
 import { classifyAiAccess } from './lib/ai-access/classify'
 import { recordAiAccessHit } from './lib/ai-access/repository'
 import type { AiBotDefinition } from './lib/ai-access/types'
 
+const CATEGORY_SLUGS = CATEGORIES.map((category) => category.slug)
+
 // 旧URL（/[locale]/blogs/[blogId]）リダイレクト判定でフェッチ対象外にする既知セグメント
-const NON_BLOG_ID_SEGMENTS = new Set<string>([...Object.values(CATEGORY_MAPED_ID), 'zenn', 'page'])
+const NON_BLOG_ID_SEGMENTS = new Set<string>([...CATEGORY_SLUGS, 'zenn', 'page'])
 
 // 記事詳細ページのcanonical URL: /{locale}/blogs/{categoryId}/{blogId}
 const ARTICLE_PATH_PATTERN = /^\/([^/]+)\/blogs\/([^/]+)\/([^/]+)$/
-const KNOWN_CATEGORY_IDS = new Set<string>(Object.values(CATEGORY_MAPED_ID))
+const KNOWN_CATEGORY_IDS = new Set<string>(CATEGORY_SLUGS)
 
 // 管理者ページのcanonical URL: /{locale}/admin(/...)
 const ADMIN_PATH_PATTERN = /^\/[^/]+\/admin(\/.*)?$/

--- a/src/static/blogs.ts
+++ b/src/static/blogs.ts
@@ -12,33 +12,3 @@ export const KEYWORD_QUERY = "keyword";
 export const PAGE_QUERY = "page";
 export const CATEGORY_QUERY = "category";
 export const BLOG_TYPE_QUERY = "blogType";
-
-export const CATEGORY_MAPED_ID = {
-  "Python": "python",
-  "TypeScript": "typescript",
-  "CSS": "css",
-  "Next.js": "next_js",
-  "Release Notes": "release_notes",
-  "AWS": "aws",
-  "レビュー": "review",
-  "雑記": "zakki",
-  "React": "react",
-  "OpenAI API": "openai_api",
-  "ガジェット": "gadget",
-  "TailwindCSS": "tailwindcss",
-  "UI": "ui_parts",
-  "プログラミング": "programming",
-  "Career": "career",
-  "LifeHack": "life_hack",
-  "時事": "news",
-  "Terraform": "terraform",
-} as const;
-
-export const CATEGORY_ARRAY = Object.entries(CATEGORY_MAPED_ID).map(([name, id]) => ({
-  id,
-  name
-}));
-
-export const CATEGORY_MAPED_NAME = Object.fromEntries(
-  Object.entries(CATEGORY_MAPED_ID).map(([key, value]) => [value, key])
-) as { [key: string]: string };

--- a/src/static/categories.generated.ts
+++ b/src/static/categories.generated.ts
@@ -1,0 +1,32 @@
+// このファイルは `node scripts/generate-categories.js` によって自動生成されます。
+// 手動で編集しないでください（次回の npm run dev / npm run build で上書きされます）。
+// microCMSの「categories」コンテンツが唯一の情報源です。
+
+export type CategoryEntry = {
+  id: string;
+  slug: string;
+  name: string;
+  name_en: string;
+};
+
+export const CATEGORIES: CategoryEntry[] = [
+  { id: "typescript", slug: "typescript", name: "TypeScript", name_en: "TypeScript" },
+  { id: "next_js", slug: "next_js", name: "Next.js", name_en: "Next.js" },
+  { id: "life_hack", slug: "life_hack", name: "LifeHack", name_en: "LifeHack" },
+  { id: "career", slug: "career", name: "Career", name_en: "Career" },
+  { id: "programming", slug: "programming", name: "プログラミング", name_en: "Programming" },
+  { id: "tailwindcss", slug: "tailwindcss", name: "TailwindCSS", name_en: "TailwindCSS" },
+  { id: "aws", slug: "aws", name: "AWS", name_en: "AWS" },
+  { id: "zakki", slug: "zakki", name: "雑記", name_en: "daily" },
+  { id: "gadget", slug: "gadget", name: "ガジェット", name_en: "Gadget" },
+  { id: "react", slug: "react", name: "React", name_en: "React" },
+  { id: "openai_api", slug: "openai_api", name: "OpenAI API", name_en: "OpenAI API" },
+  { id: "css", slug: "css", name: "CSS", name_en: "CSS" },
+  { id: "review", slug: "review", name: "レビュー", name_en: "Review" },
+  { id: "news", slug: "news", name: "時事", name_en: "News" },
+  { id: "terraform", slug: "terraform", name: "Terraform", name_en: "Terraform" },
+  { id: "ui-parts", slug: "ui_parts", name: "UI", name_en: "UI" },
+  { id: "release_notes", slug: "release_notes", name: "Release Notes", name_en: "Release Notes" },
+  { id: "python", slug: "python", name: "Python", name_en: "Python" },
+  { id: "test", slug: "test", name: "テスト", name_en: "test" },
+];

--- a/src/static/categories.ts
+++ b/src/static/categories.ts
@@ -1,0 +1,43 @@
+import { CATEGORIES } from "@/static/categories.generated";
+import type { CategoryEntry } from "@/static/categories.generated";
+
+export type { CategoryEntry };
+export { CATEGORIES };
+
+// 記事にカテゴリが1件も紐付かない場合のみ使う最終フォールバック
+export const DEFAULT_CATEGORY_ID = "programming";
+
+export const findCategoryBySlug = (slug: string): CategoryEntry | undefined =>
+  CATEGORIES.find((category) => category.slug === slug);
+
+export const findCategoryByContentId = (id: string): CategoryEntry | undefined =>
+  CATEGORIES.find((category) => category.id === id);
+
+// URLスラッグ・content id・表示名(ja/en)のいずれでもカテゴリを解決する（?category=クエリの後方互換のため）
+export const resolveCategoryEntry = (value: string): CategoryEntry | undefined =>
+  CATEGORIES.find(
+    (category) =>
+      category.slug === value ||
+      category.id === value ||
+      category.name === value ||
+      category.name_en === value,
+  );
+
+// "programming"がCATEGORIES自体に存在しない極端なケースのみ使う最終手段のフォールバック
+const HARD_FALLBACK_ENTRY: CategoryEntry = {
+  id: DEFAULT_CATEGORY_ID,
+  slug: DEFAULT_CATEGORY_ID,
+  name: "プログラミング",
+  name_en: "Programming",
+};
+
+// content idからカテゴリを解決する唯一の入り口。見つからない場合（記事に紐づくカテゴリが
+// microCMS側で削除された等）は必ずDEFAULT_CATEGORY_IDのエントリにフォールバックし、
+// 呼び出し箇所ごとに異なる場当たり的なフォールバック（生idの通過・未翻訳文字列の表示等）を防ぐ。
+export const resolveCategoryOrDefault = (contentId: string | undefined): CategoryEntry => {
+  if (contentId) {
+    const entry = findCategoryByContentId(contentId);
+    if (entry) return entry;
+  }
+  return findCategoryBySlug(DEFAULT_CATEGORY_ID) ?? HARD_FALLBACK_ENTRY;
+};

--- a/src/types/microcms.ts
+++ b/src/types/microcms.ts
@@ -1,4 +1,3 @@
-import { CATEGORY_MAPED_ID } from "@/static/blogs";
 import type {
   MicroCMSDate,
   MicroCMSImage,
@@ -114,8 +113,6 @@ export type TableOfContentsType = {
   label: string;
   domName: "h2" | "h3";
 };
-
-export type MappedKeyLiteralType = keyof typeof CATEGORY_MAPED_ID;
 
 // カテゴリAPIのレスポンス型
 export type CategoriesApiResponseType = BaseMicroCMSApiListDataType<CategoriesContentType>;


### PR DESCRIPTION
## Summary
- 「test」カテゴリを公開しても本番に反映されない問題を修正。サイト全体のカテゴリ機能が `src/static/blogs.ts` にハードコードされた静的マップ(`CATEGORY_MAPED_ID`)だけで組み立てられており、microCMSの`categories`コンテンツをほぼ使っていなかったことが原因。実際「test」カテゴリを付けた記事は本番で「プログラミング」カテゴリとして誤表示されていた。
- `scripts/generate-categories.js`を新設し、`npm run update-rss`と同じビルド時生成パターンでmicroCMSの`categories`エンドポイントを取得、`src/static/categories.generated.ts`に書き出す(`predev`/`prebuild`フックで自動実行)。以降、新しいカテゴリをmicroCMSで追加するだけで反映されるようになる。
- `getPrimaryCategoryId`をカテゴリ名の静的マップ引きから、microCMSのcontent idを直接使う方式に変更(記事誤分類の直接の修正箇所)。サイドバー・カテゴリページ・sitemap・middleware等の全消費箇所も生成データベースに移行し、静的マップとi18nの`categories`翻訳名前空間を削除。
- 副次的に、microCMS側カテゴリ「UI」のcontent id(`ui-parts`)とアプリの静的スラッグ(`ui_parts`)の不一致により、UIカテゴリの記事一覧が常に0件になっていたバグも修正。
- 8視点の多角的レビューで見つかった「カテゴリ未検出時のフォールバック不整合」(`getPrimaryCategoryId`/`CategoryTag`/`RelatedContentItem`でバラバラの挙動)を`resolveCategoryOrDefault()`に統一。生成スクリプトのmicroCMS取得にタイムアウトを追加し、`generateStaticParams`の直列実行を`Promise.all`で並列化。

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build` が成功すること(変更前と同じ既存の警告・エラー件数であることを確認済み)
- [x] `npm run dev` で `/ja/blogs` サイドバーに「テスト」が表示される
- [x] `/ja/blogs/test` が200で表示され、対象記事が一覧に出る
- [x] 記事詳細が `/ja/blogs/test/<blogId>` で配信され、カテゴリタグが「テスト」になっている(旧URル `/ja/blogs/programming/<blogId>` は404)
- [x] `/ja/blogs/ui_parts` に記事が表示される(従来0件だったバグの修正確認)
- [x] sitemap.xml / `/ja/docs/llms.txt` / JSON-LDで一貫してカテゴリが反映されている
- [ ] デプロイ後、本番の https://ryotablog.jp/ja/blogs/test で最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWi2dr6CBoKg7q8jWK44XD