### PR TITLE
fix: ソフトナビゲーション時にもしもアフィリエイトのウィジェットが表示されない問題を修正

### DIFF
--- a/src/components/ArticleBody/RichEditor/ExecutableScript/index.tsx
+++ b/src/components/ArticleBody/RichEditor/ExecutableScript/index.tsx
@@ -1,0 +1,111 @@
+"use client"
+import { useEffect, useRef } from "react";
+
+type ExecutableScriptProps = {
+  // 元のscriptタグの属性（src, type, async など）
+  attribs: Record<string, string>;
+  // 元のscriptタグのインラインコード（外部scriptの場合は空文字）
+  code: string;
+};
+
+// もしもアフィリエイト(かんたんリンク)のローダーがbundle.jsのscript要素に付与するID
+const MOSHIMO_LOADER_ID = "msmaflink";
+
+// もしものbundle.jsはウィジェット描画処理をDOMContentLoaded/loadイベントでのみ発火するため、
+// 両イベントが発火済みのソフトナビゲーション後は、loadイベントを自前で再ディスパッチして
+// 描画をトリガーする必要がある。同一記事内の複数ウィジェットが同時にマウントされるため、
+// モジュールスコープのフラグで「1回のマウントバッチにつき1回だけ」実行されるように制御する
+let moshimoBatchStarted = false;
+let moshimoTriggerScheduled = false;
+let bundleExistedBeforeBatch = false;
+
+const prepareMoshimoBatch = () => {
+  if (moshimoBatchStarted) return;
+  moshimoBatchStarted = true;
+  // エフェクトのフラッシュは同期的に完了するため、マイクロタスクでフラグを戻すと
+  // 「同じコミットでマウントされたウィジェット群 = 1バッチ」として扱える
+  queueMicrotask(() => {
+    moshimoBatchStarted = false;
+  });
+  bundleExistedBeforeBatch = !!document.getElementById(MOSHIMO_LOADER_ID);
+  // 前のページで積まれた未処理のキューが残っていると、bundle.jsが古いエントリを
+  // 再処理して重複描画や例外を起こすため、このページ分を積む前に破棄する
+  const loader = window.msmaflink;
+  if (loader && Array.isArray(loader.q)) {
+    loader.q.length = 0;
+  }
+};
+
+const scheduleMoshimoTrigger = () => {
+  if (moshimoTriggerScheduled) return;
+  moshimoTriggerScheduled = true;
+  // 後続のバッチがモジュール変数を上書きしても影響しないよう、この時点の値を捕捉する
+  const bundleExisted = bundleExistedBeforeBatch;
+  // ウィジェット全件のscript実行(キュー積み込み)が終わってから発火させる
+  setTimeout(() => {
+    moshimoTriggerScheduled = false;
+    const bundle = document.getElementById(MOSHIMO_LOADER_ID);
+    if (!bundle) return;
+    const dispatch = () => {
+      // ウィジェットの描画先が既にアンマウントされていれば何もしない
+      if (!document.querySelector('[id^="msmaflink-"]')) return;
+      window.dispatchEvent(new Event("load"));
+    };
+    if (bundleExisted) {
+      // bundle.jsが前のページ遷移でロード済みの場合は即時ディスパッチできる
+      dispatch();
+      return;
+    }
+    // このバッチで初めて生成されたbundle.jsはロード完了を待ってからディスパッチする
+    bundle.addEventListener("load", dispatch, { once: true });
+  }, 0);
+};
+
+// React(html-react-parser)経由でDOMに挿入されたscriptタグはブラウザ仕様により実行されない。
+// そのため本文中のscriptタグをこのコンポーネントに置き換え、マウント時にDOM APIで
+// script要素を生成し直して実行させる。ソフトナビゲーションで記事へ遷移した場合も
+// 再マウントされるため、ハードナビゲーションと同様にウィジェット等が描画される
+const ExecutableScript = ({ attribs, code }: ExecutableScriptProps) => {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    if (!anchor || !anchor.parentNode) return;
+
+    const isMoshimo = code.includes(MOSHIMO_LOADER_ID);
+    if (isMoshimo) {
+      prepareMoshimoBatch();
+    }
+
+    const script = document.createElement("script");
+    Object.entries(attribs).forEach(([name, value]) => {
+      script.setAttribute(name, value);
+    });
+    if (code) {
+      script.text = code;
+    }
+    // bundle.jsは「script要素の直後の兄弟がウィジェット本体かどうか」を重複描画ガードに
+    // 使っているため、ラッパー内ではなく元のscriptタグと同じ位置(anchorの直後)に挿入する
+    anchor.parentNode.insertBefore(script, anchor.nextSibling);
+
+    if (isMoshimo) {
+      scheduleMoshimoTrigger();
+    }
+
+    return () => {
+      script.remove();
+    };
+    // 同一インスタンスの再レンダリングで重複実行しないよう、マウント時のみ実行する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <span ref={anchorRef} />;
+};
+
+export default ExecutableScript;
+
+declare global {
+  interface Window {
+    msmaflink?: ((...args: unknown[]) => void) & { q?: unknown[] };
+  }
+}

--- a/src/components/ArticleBody/RichEditor/ReplaceUiParts.lib.tsx
+++ b/src/components/ArticleBody/RichEditor/ReplaceUiParts.lib.tsx
@@ -21,6 +21,7 @@ import ExternalLink from "@/components/UiParts/ExternalLink";
 import PopupModal from "@/components/UiParts/PopupModal";
 import CustomU from "@/components/ArticleBody/RichEditor/CustomUI/CustomU";
 import CopyableText from "@/components/ArticleBody/RichEditor/CopyableText";
+import ExecutableScript from "@/components/ArticleBody/RichEditor/ExecutableScript";
 
 // Next.js 16では、Client Componentに対してssr: falseを使用できない
 // TwitterCardは"use client"でマークされているため、通常のimportに変更
@@ -41,6 +42,15 @@ export const customReplaceOptions: HTMLReactParserOptions = {
       // ハイドレーションエラーが生じるため、scriptタグを削除
       if (domNode.name === "script" && domNode.attribs.src === "//cdn.iframe.ly/embed.js") {
         return <></>;
+      }
+
+      // React経由でDOMに挿入されたscriptタグはブラウザが実行しないため、
+      // ソフトナビゲーションではアフィリエイトウィジェット等が描画されない。
+      // クライアント側でscript要素を生成し直して実行するコンポーネントに置き換える
+      if (domNode.name === "script") {
+        const child = domNode.children[0];
+        const code = child && "data" in child ? child.data : "";
+        return <ExecutableScript attribs={domNode.attribs} code={code} />;
       }
 
       if (


### PR DESCRIPTION
## 概要

もしもアフィリエイト（かんたんリンク）のウィジェットが、ハードナビゲーションでは表示されるのに、一覧ページからのクライアントサイド遷移（ソフトナビゲーション）では「リンク」というプレースホルダーテキストのまま表示されない問題を修正します。

対象ページ例: https://ryotablog.jp/ja/blogs/zakki/best-buy-2026-first-half

## 原因（2段階）

1. **scriptタグが実行されない**: 記事本文の `<script>` は html-react-parser のデフォルト処理で React 要素として描画されるが、React/DOM API 経由で挿入された script はブラウザ仕様により実行されない。ハードナビゲーションではブラウザのHTMLパーサーが直接実行するため表示されていた。
2. **再実行だけでは描画されない**: もしもの bundle.js はウィジェット描画関数を `window` の `DOMContentLoaded` / `load` イベントでのみ発火する（bundle.js を直接解析して確認）。ソフトナビゲーション後はこれらのイベントが二度と発火しないため、script を再実行してキューに積むだけでは描画されない。

## 変更内容

- **新規 `ExecutableScript` コンポーネント**: 本文中の script タグをマウント時に DOM API で生成し直して実行するクライアントコンポーネント。msmaflink 系 script には追加で以下を行う:
  - ページ遷移をまたいで残る未処理キューをマウントバッチごとに破棄（重複描画・例外防止）
  - bundle.js のロード完了を待って合成 `load` イベントをディスパッチし描画をトリガー
  - bundle.js の重複描画ガードが「script 直後の兄弟がウィジェット本体か」の判定に依存するため、script を元のタグと同じ位置（anchor の直後の兄弟）に挿入
- **`ReplaceUiParts.lib.tsx`**: script タグを `ExecutableScript` に置き換える分岐を追加（既存の iframely 除去分岐は維持）

## 検証

dev（StrictModeあり）と本番ビルド（StrictModeなし）の両方で実機検証済み:

| シナリオ | 結果 |
|---|---|
| ハードロード | 8/8 描画・重複なし |
| 一覧→記事のソフトナビ（バグ再現手順） | 8/8 描画 ✅ |
| ソフトナビ離脱→再訪問（bundle.js ロード済み） | 8/8 描画・重複なし |
| ブラウザバック/フォワードでの復帰 | 8/8 描画・重複なし |
| en 版記事 | 8/8 描画 |
| Twitter 埋め込み・iframely 記事（回帰確認） | 正常描画・エラーなし |

- 全60記事（ja/en）の script タグを microCMS API でインベントリ化し、影響対象が msmaflink / Twitter widgets.js / iframely の3種のみで `document.write` 系が存在しないことを確認
- 合成 `load` イベントの副作用を監査: GTM/GA（afterInteractive）・Twitter widgets.js・iframely・next/script の lazyOnload いずれも window load 再発火の影響を受けないことをコードレベルで確認
- `npm run build` 成功 / lint 0エラー / `tsc --noEmit` 変更ファイルのエラーなし / 既存ユニットテストの結果は変更前と同一

🤖 Generated with [Claude Code](https://claude.com/claude-code)