### PR TITLE
feat: MDXレンダリングパイプラインと埋め込みコンポーネント移行 (#236)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,12 +24,15 @@ const config: StorybookConfig = {
   typescript: {
     reactDocgen: "react-docgen-typescript"
   },
-  // tsconfigのpaths(@/*)とNext.jsモジュールをViteで解決するためのエイリアス設定
+  // tsconfigのpaths(@/*, #content/*)とNext.jsモジュールをViteで解決するためのエイリアス設定
   viteFinal: async (config) => {
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...config.resolve.alias,
       "@": path.resolve(__dirname, "../src"),
+      // #content/* はVelite生成物(.velite/、tsconfig.jsonのpathsと同じマッピング)。
+      // static/categories.ts等がVeliteデータを参照するため、Storybookのビルドにも解決先が必要
+      "#content": path.resolve(__dirname, "../.velite"),
       // Next.jsモジュールのモック（Vite環境では動作しないため）
       "next/image": path.resolve(__dirname, "./mocks/next-image.tsx"),
       "next/link": path.resolve(__dirname, "./mocks/next-link.tsx"),

--- a/content/ogp-cache.json
+++ b/content/ogp-cache.json
@@ -1,0 +1,56 @@
+{
+  "https://github.com/ryota-09/ryota-blog/blob/main/src/components/Pagination/EllipsisMenu/index.tsx": {
+    "url": "https://github.com/ryota-09/ryota-blog/blob/main/src/components/Pagination/EllipsisMenu/index.tsx",
+    "title": "ryota-blog/src/components/Pagination/EllipsisMenu/index.tsx at main · ryota-09/ryota-blog",
+    "description": "Ryota-Blog with Next.js. Contribute to ryota-09/ryota-blog development by creating an account on GitHub.",
+    "image": "https://opengraph.githubassets.com/b2b82fbe11e84f494149a174cd0cb5734914b510a059bb2096b77a9a1c05bd9c/ryota-09/ryota-blog",
+    "favicon": "https://github.githubassets.com/favicons/favicon",
+    "hostname": "github.com",
+    "ok": true
+  },
+  "https://github.com/ryota-09/ryota-blog/blob/main/src/components/Pagination/index.tsx": {
+    "url": "https://github.com/ryota-09/ryota-blog/blob/main/src/components/Pagination/index.tsx",
+    "title": "ryota-blog/src/components/Pagination/index.tsx at main · ryota-09/ryota-blog",
+    "description": "Ryota-Blog with Next.js. Contribute to ryota-09/ryota-blog development by creating an account on GitHub.",
+    "image": "https://opengraph.githubassets.com/b2b82fbe11e84f494149a174cd0cb5734914b510a059bb2096b77a9a1c05bd9c/ryota-09/ryota-blog",
+    "favicon": "https://github.githubassets.com/favicons/favicon",
+    "hostname": "github.com",
+    "ok": true
+  },
+  "https://note.com/ryota_blog_0922/n/n4c8884e880fe": {
+    "url": "https://note.com/ryota_blog_0922/n/n4c8884e880fe",
+    "title": "ソフトウェアエンジニアの結婚相談所体験談｜ぼんやり生活手帖",
+    "description": "白状すると、僕が結婚相談所のドアを叩いた理由は、たぶん思っているより、ずっと地味です。  「土日が、急に暇になったから」  こんにちは、ぼんやり生活手帖です ☺️  先に、結末から言ってしまいます。 僕は婚活を始めて1年半で、結婚しました。  今回は、ソフトウェアエンジニアの僕が、マッチングアプリから結婚相談所まで渡り歩いた、その1年半の一部始終を、時系列でつらつら書いていきます。読み終わるころには、「婚活って、相談所って、そういう世界なんだ」と、少しだけ解像度が上がっているはずです。とくに、僕みたいに出会いの少ない仕事をしていて、これから婚活を始めようか迷っている人には、地図がわりに",
+    "image": "https://assets.st-note.com/production/uploads/images/289502382/rectangle_large_type_2_5ee654b348b6657be9b04ee1bd6abda1.jpeg?fit=bounds&quality=85&width=1280",
+    "favicon": "https://assets.st-note.com/poc-image/manual/note-common-images/production/svg/production.ico",
+    "hostname": "note.com",
+    "ok": true
+  },
+  "https://techblog.yahoo.co.jp/entry/2022090530337093/": {
+    "url": "https://techblog.yahoo.co.jp/entry/2022090530337093/",
+    "title": "ヤフー全社横断「Webパフォーマンス改善」の取り組み (Core Web Vitalsスコアの向上)",
+    "description": "ヤフー全社でCore Web Vitals指標の改善に取り組んだ際の「全社Webパフォーマンス改善プロジェクト」について、経緯や施策内容をすべてご紹介します。",
+    "image": "https://s.yimg.jp/images/tecblog/2022-H1/corewebvitals/ogp_20220829T125013_b_w_025.png",
+    "favicon": "https://s.yimg.jp/i/docs/integrate/images/common/about_yahoo_webclip.png",
+    "hostname": "techblog.yahoo.co.jp",
+    "ok": true
+  },
+  "https://zenn.dev/ryota_09/articles/06ec306f0ef9ee": {
+    "url": "https://zenn.dev/ryota_09/articles/06ec306f0ef9ee",
+    "title": "APIで取得したデータをもとに、動的にメタ情報を設定する方法(Next.js App Router)",
+    "description": null,
+    "image": "https://res.cloudinary.com/zenn/image/upload/s--XicD5lIF--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:API%25E3%2581%25A7%25E5%258F%2596%25E5%25BE%2597%25E3%2581%2597%25E3%2581%259F%25E3%2583%2587%25E3%2583%25BC%25E3%2582%25BF%25E3%2582%2592%25E3%2582%2582%25E3%2581%25A8%25E3%2581%25AB%25E3%2580%2581%25E5%258B%2595%25E7%259A%2584%25E3%2581%25AB%25E3%2583%25A1%25E3%2582%25BF%25E6%2583%2585%25E5%25A0%25B1%25E3%2582%2592%25E8%25A8%25AD%25E5%25AE%259A%25E3%2581%2599%25E3%2582%258B%25E6%2596%25B9%25E6%25B3%2595%2528Next.js%2520App%2520Router%2529%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:%25E3%2582%258A%25E3%2582%2587%25E3%2581%259F%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdGF0aWMuemVubi5zdHVkaW8vdXNlci11cGxvYWQvYXZhdGFyLzI2Mzg3YjI4MWEuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png?_a=BACMTiAE",
+    "favicon": "https://zenn.dev/favicon.ico",
+    "hostname": "zenn.dev",
+    "ok": true
+  },
+  "https://zenn.dev/ryota_09/articles/cdef1901df899b": {
+    "url": "https://zenn.dev/ryota_09/articles/cdef1901df899b",
+    "title": "【Next.js / App Router】 opengraph-image.tsxのOG画像内フォントの変更方法",
+    "description": null,
+    "image": "https://res.cloudinary.com/zenn/image/upload/s--zPzk6dIe--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%25E3%2580%2590Next.js%2520%252F%2520App%2520Router%25E3%2580%2591%2520opengraph-image.tsx%25E3%2581%25AEOG%25E7%2594%25BB%25E5%2583%258F%25E5%2586%2585%25E3%2583%2595%25E3%2582%25A9%25E3%2583%25B3%25E3%2583%2588%25E3%2581%25AE%25E5%25A4%2589%25E6%259B%25B4%25E6%2596%25B9%25E6%25B3%2595%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:%25E3%2582%258A%25E3%2582%2587%25E3%2581%259F%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdGF0aWMuemVubi5zdHVkaW8vdXNlci11cGxvYWQvYXZhdGFyLzI2Mzg3YjI4MWEuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png?_a=BACMTiAE",
+    "favicon": "https://zenn.dev/favicon.ico",
+    "hostname": "zenn.dev",
+    "ok": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.2.4",
         "react-scroll": "^1.9.0",
         "react-syntax-highlighter": "^15.5.0",
+        "react-tweet": "^3.3.1",
         "tailwind-merge": "^2.3.0"
       },
       "devDependencies": {
@@ -42,6 +43,7 @@
         "@storybook/test": "8.6.18",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^15.0.5",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20",
         "@types/react": "19.2.7",
         "@types/react-dom": "19.2.3",
@@ -8990,6 +8992,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -11348,7 +11357,6 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17650,6 +17658,21 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/react-tweet": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.3.1.tgz",
+      "integrity": "sha512-0Gj1YgBTe1K85NBMoWBlUc17Rdc67gIJLlacrVgj+3jWIoXpFfxPdZ1U5OnWkkF9zxhphqs2pY1i//JBfP3Qog==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.3",
+        "clsx": "^2.0.0",
+        "swr": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "dev": true,
@@ -19006,6 +19029,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "dev": true,
@@ -19812,6 +19848,15 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-dom": "^19.2.4",
     "react-scroll": "^1.9.0",
     "react-syntax-highlighter": "^15.5.0",
+    "react-tweet": "^3.3.1",
     "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
@@ -60,6 +61,7 @@
     "@storybook/test": "8.6.18",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^15.0.5",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/scripts/fetch-ogp-cache.mjs
+++ b/scripts/fetch-ogp-cache.mjs
@@ -1,0 +1,167 @@
+// LinkCard(#236)のためのOGPキャッシュ生成スクリプト。
+// content/blogs配下の全MDXから <LinkCard url="..." /> のURLを抽出し、
+// 各URLへfetchしてOGP(og:title/og:description/og:image/favicon)をパースして
+// content/ogp-cache.json に保存する(URL→メタのマップ)。
+//
+// 実行方法: node ./scripts/fetch-ogp-cache.mjs
+// ビルド時ではなく手動実行のスクリプト(記事に新しいLinkCardが増えたときに再実行しコミットする)。
+// 失敗したURLはtitle=URLのフォールバックエントリを書く。
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONTENT_BLOGS_DIR = path.join(__dirname, "..", "content", "blogs");
+const OUTPUT_PATH = path.join(__dirname, "..", "content", "ogp-cache.json");
+
+// content/blogs配下の全 index.*.mdx ファイルパスを再帰的に収集する
+const collectMdxFiles = (dir) => {
+  const entries = readdirSync(dir);
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...collectMdxFiles(fullPath));
+    } else if (/^index\.(ja|en)\.mdx$/.test(entry)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+};
+
+// <LinkCard url="..." /> からURLを抽出する(シングル/ダブルクォート両対応)
+const extractLinkCardUrls = (mdxContent) => {
+  const urls = [];
+  const pattern = /<LinkCard\s+url=["']([^"']+)["']\s*\/?>/g;
+  let match;
+  while ((match = pattern.exec(mdxContent)) !== null) {
+    urls.push(match[1]);
+  }
+  return urls;
+};
+
+// HTML文字列からOGPタグ(og:title/og:description/og:image)とfaviconを簡易パースする
+const parseOgpFromHtml = (html, baseUrl) => {
+  const getMetaContent = (property) => {
+    // property/name いずれの属性順序・引用符種別にも対応する簡易正規表現
+    const patterns = [
+      new RegExp(
+        `<meta[^>]*(?:property|name)=["']${property}["'][^>]*content=["']([^"']*)["'][^>]*>`,
+        "i",
+      ),
+      new RegExp(
+        `<meta[^>]*content=["']([^"']*)["'][^>]*(?:property|name)=["']${property}["'][^>]*>`,
+        "i",
+      ),
+    ];
+    for (const pattern of patterns) {
+      const m = html.match(pattern);
+      if (m) return m[1];
+    }
+    return undefined;
+  };
+
+  const titleTagMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+
+  const resolveUrl = (value) => {
+    if (!value) return undefined;
+    try {
+      return new URL(value, baseUrl).toString();
+    } catch {
+      return undefined;
+    }
+  };
+
+  const title = getMetaContent("og:title") || titleTagMatch?.[1]?.trim() || baseUrl;
+  const description = getMetaContent("og:description") || getMetaContent("description");
+  const image = resolveUrl(getMetaContent("og:image"));
+
+  // faviconはlinkタグ(rel="icon"系)から抽出。無ければ/favicon.icoにフォールバック
+  const faviconMatch = html.match(
+    /<link[^>]*rel=["'](?:shortcut icon|icon|apple-touch-icon)["'][^>]*href=["']([^"']*)["'][^>]*>/i,
+  );
+  const favicon = resolveUrl(faviconMatch?.[1]) ?? resolveUrl("/favicon.ico");
+
+  return { title, description, image, favicon };
+};
+
+const fetchOgp = async (url) => {
+  console.log(`fetching: ${url}`);
+  try {
+    const response = await fetch(url, {
+      headers: {
+        // 一部サイトはUAが無いとbotとして弾くため、一般的なブラウザUAを付与する
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const html = await response.text();
+    const hostname = new URL(url).hostname;
+    const ogp = parseOgpFromHtml(html, url);
+    return {
+      url,
+      title: ogp.title,
+      description: ogp.description ?? null,
+      image: ogp.image ?? null,
+      favicon: ogp.favicon ?? null,
+      hostname,
+      ok: true,
+    };
+  } catch (error) {
+    console.error(`  failed: ${error.message}`);
+    return {
+      url,
+      title: url,
+      description: null,
+      image: null,
+      favicon: null,
+      hostname: (() => {
+        try {
+          return new URL(url).hostname;
+        } catch {
+          return url;
+        }
+      })(),
+      ok: false,
+    };
+  }
+};
+
+const main = async () => {
+  const mdxFiles = collectMdxFiles(CONTENT_BLOGS_DIR);
+  const urlSet = new Set();
+  for (const file of mdxFiles) {
+    const content = readFileSync(file, "utf-8");
+    for (const url of extractLinkCardUrls(content)) {
+      urlSet.add(url);
+    }
+  }
+
+  const urls = [...urlSet].sort();
+  console.log(`${urls.length}件のLinkCard URLを検出しました`);
+
+  const results = {};
+  for (const url of urls) {
+    const meta = await fetchOgp(url);
+    results[url] = meta;
+  }
+
+  // 決定的な出力にするためキーをソートして書き出す
+  const sortedResults = Object.fromEntries(
+    Object.keys(results)
+      .sort()
+      .map((key) => [key, results[key]]),
+  );
+
+  writeFileSync(OUTPUT_PATH, JSON.stringify(sortedResults, null, 2) + "\n", "utf-8");
+
+  const okCount = Object.values(results).filter((r) => r.ok).length;
+  console.log(`完了: ${okCount}/${urls.length}件成功 → ${OUTPUT_PATH}`);
+};
+
+main();

--- a/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
@@ -3,35 +3,42 @@ import { notFound } from "next/navigation";
 
 import ArticleBody from "@/components/ArticleBody";
 import BreadcrumbList from "@/components/BreadcrumbList";
-import { generateBreadcrumbAssets, getPrimaryCategoryId, buildPageUrl, buildLanguageAlternates } from "@/lib";
-import { getBlogByIdByLocale, getBlogByIdByLocaleCached, getAllBlogListByLocale } from "@/lib/microcms";
-import type { BlogsContentType } from "@/types/microcms";
+import { buildPageUrl, buildLanguageAlternates } from "@/lib";
+import {
+  getBlogBySlugByLocaleCached,
+  getAllBlogListByLocale,
+  getPrimaryCategoryIdFromBlogPost,
+  resolveRelatedBlogs,
+  generateBreadcrumbAssetsFromBlogPost,
+} from "@/lib/content";
+import type { ContentLocale } from "@/types/content";
 import JsonLD from "@/components/Head/JsonLD";
 import RelatedContentList from "@/components/RelatedContentList";
 import { locales } from '@/i18n/config';
 
-// キャッシュ設定: 24時間のISR（Incremental Static Regeneration）
-export const revalidate = 86400; // 24時間
+// コンテンツはリポジトリ内(content/)で管理されビルド時に確定するため、ISRは不要(更新=再デプロイ)。
+// また、MDX本文のレンダリング(MdxContent)は new Function 評価を伴い、Cloudflare Workersランタイムでは
+// 動的コード生成が禁止されているため、再検証時のWorker内レンダリングを発生させないよう完全静的にする。
+export const revalidate = false;
 
 // Next.js 16では静的な値のみ許可されるため、force-staticに統一
-// 開発環境でもISRで動作する
 export const dynamic = 'force-static';
 
 export async function generateStaticParams() {
   const params = [];
-  
+
   for (const locale of locales) {
-    const blogList = await getAllBlogListByLocale(locale, { fields: "id,category" });
+    const blogList = getAllBlogListByLocale(locale);
     for (const blog of blogList) {
-      const categoryId = getPrimaryCategoryId(blog);
+      const categoryId = getPrimaryCategoryIdFromBlogPost(blog);
       params.push({
         locale,
         category: categoryId,
-        blogId: blog.id
+        blogId: blog.slug
       });
     }
   }
-  
+
   return params;
 }
 
@@ -41,7 +48,7 @@ export async function generateMetadata(
   // Next.js 16では、paramsを非同期で取得する必要がある
   const { blogId, locale, category } = await params;
   // NOTE: ページ本体と同じ cached フェッチを使い、同一リクエスト内の二重フェッチを避ける
-  const data = await getBlogByIdByLocaleCached(locale, blogId);
+  const data = getBlogBySlugByLocaleCached(locale as ContentLocale, blogId);
 
   // 記事自身の絶対URL（og:url / canonical に使用）
   const blogUrl = buildPageUrl(locale, "blogs", category, blogId);
@@ -80,51 +87,34 @@ type PageProps = {
 const Page = async ({ params }: PageProps) => {
   // Next.js 16では、paramsを非同期で取得する必要がある
   const { blogId, category: categoryParam, locale } = await params;
-  
-  let data: BlogsContentType;
-  let isEnabled = false;
-  let draftKey: string | undefined;
+  const contentLocale = locale as ContentLocale;
 
-  // 開発環境でのみドラフトモードを有効化
-  if (process.env.NODE_ENV === 'development') {
-    const { draftMode, cookies } = await import('next/headers');
-    // Next.js 16では、draftMode()とcookies()も非同期になった
-    const draftModeResult = await draftMode();
-    isEnabled = draftModeResult.isEnabled;
-
-    if (isEnabled) {
-      const currentCookies = await cookies();
-      draftKey = currentCookies.get('draftKey')?.value;
-    }
-  }
-
+  let data;
   try {
-    if (isEnabled && draftKey) {
-      data = await getBlogByIdByLocale(locale, blogId, { draftKey: draftKey });
-    } else {
-      // generateMetadata と同じ cached フェッチで重複排除する
-      data = await getBlogByIdByLocaleCached(locale, blogId);
-    }
-  } catch (error) {
+    // generateMetadata と同じ cached フェッチで重複排除する
+    data = getBlogBySlugByLocaleCached(contentLocale, blogId);
+  } catch {
     notFound();
   }
 
   // URLのカテゴリパラメータが実際のブログのプライマリカテゴリと一致するかチェック
-  const actualCategoryId = getPrimaryCategoryId(data);
+  const actualCategoryId = getPrimaryCategoryIdFromBlogPost(data);
   if (actualCategoryId !== categoryParam) {
     notFound();
   }
 
-  const breadcrumbAssets = await generateBreadcrumbAssets(data, locale);
+  const breadcrumbAssets = await generateBreadcrumbAssetsFromBlogPost(data, contentLocale);
+  const relatedBlogs = resolveRelatedBlogs(contentLocale, data.related);
+
   return (
     <div className="max-w-[1028px] mx-auto px-2 md:px-0">
       <BreadcrumbList items={breadcrumbAssets} />
       <article className=" bg-white dark:bg-black border-2 dark:border-gray-600 px-4">
-        <ArticleBody data={data} locale={locale} />
+        <ArticleBody data={data} locale={contentLocale} />
       </article>
-      {data.relatedContent.length >= 1 && (
+      {relatedBlogs.length >= 1 && (
         <aside className="my-8">
-          <RelatedContentList data={data.relatedContent} />
+          <RelatedContentList data={relatedBlogs} />
         </aside>
       )}
       <JsonLD data={data} locale={locale} />

--- a/src/components/ArticleBody/Embeds/AmazonLink/index.stories.tsx
+++ b/src/components/ArticleBody/Embeds/AmazonLink/index.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import AmazonLink from ".";
+
+const meta = {
+  title: "ArticleBody/Embeds/AmazonLink",
+  component: AmazonLink,
+  tags: ["autodocs"],
+} satisfies Meta<typeof AmazonLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    href: "//af.moshimo.com/af/c/click?a_id=2351007&p_id=170&pc_id=185&pl_id=4062&url=https%3A%2F%2Fwww.amazon.co.jp%2Fdp%2F4873115655",
+    image: "https://images-fe.ssl-images-amazon.com/images/I/51xHT9ZnmNL._SL160_.jpg",
+    title: "リーダブルコード ―より良いコードを書くためのシンプルで実践的なテクニック (Theory in practice)",
+    trackingImage: "//i.moshimo.com/af/i/impression?a_id=2351007&p_id=170&pc_id=185&pl_id=4062",
+  },
+};

--- a/src/components/ArticleBody/Embeds/AmazonLink/index.tsx
+++ b/src/components/ArticleBody/Embeds/AmazonLink/index.tsx
@@ -1,0 +1,35 @@
+import ExternalLink from "@/components/UiParts/ExternalLink";
+
+type AmazonLinkProps = {
+  href: string;
+  image: string;
+  title: string;
+  trackingImage?: string;
+};
+
+// 現行 AmazonLinkCard(RichEditor/AmazonLinkCard + amazonLinkCardOptions)のスタイルを踏襲し、
+// html-react-parserを使わずprops(href/image/title/trackingImage)から直接描画する。
+// trackingImageは1x1のトラッキングピクセルとしてそのまま描画する(もしもアフィリエイトの計測用)。
+const AmazonLink = ({ href, image, title, trackingImage }: AmazonLinkProps) => {
+  return (
+    <aside className="w-full my-10">
+      <ExternalLink
+        href={href}
+        className="relative flex flex-col md:flex-row items-center gap-8 px-4 py-8 md:px-6 md:py-4 border-[#D0AD77] border-[6px] hover:transition hover:opacity-80 hover:text-[#D0AD77] after:content-['Amazon'] after:text-gray-700 after:bg-[#D0AD77] after:absolute after:py-0 lg:after:py-2 md:after:py-0.5 after:px-4 after:w-auto after:top-0 after:right-0"
+      >
+        <figure className="overflow-hidden object-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={image} alt={title} />
+        </figure>
+        <br />
+        {title}
+      </ExternalLink>
+      {trackingImage && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={trackingImage} width={1} height={1} alt="" style={{ display: "none" }} />
+      )}
+    </aside>
+  );
+};
+
+export default AmazonLink;

--- a/src/components/ArticleBody/Embeds/Copyable/index.stories.tsx
+++ b/src/components/ArticleBody/Embeds/Copyable/index.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Copyable from ".";
+
+const meta = {
+  title: "ArticleBody/Embeds/Copyable",
+  component: Copyable,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Copyable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// MDXの<Copyable>A2R7FE3K</Copyable>(紹介コード)の実例を再現
+export const Default: Story = {
+  args: {
+    children: "A2R7FE3K",
+  },
+};

--- a/src/components/ArticleBody/Embeds/Copyable/index.tsx
+++ b/src/components/ArticleBody/Embeds/Copyable/index.tsx
@@ -1,0 +1,7 @@
+import CopyableText from "@/components/ArticleBody/RichEditor/CopyableText";
+
+// MDXの<Copyable>text</Copyable>から既存のCopyableText(コピー可能なコード風テキスト)へ橋渡しする。
+// 見た目・挙動は既存コンポーネントをそのまま流用する。
+const Copyable = CopyableText;
+
+export default Copyable;

--- a/src/components/ArticleBody/Embeds/LinkCard/index.stories.tsx
+++ b/src/components/ArticleBody/Embeds/LinkCard/index.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import LinkCard from ".";
+
+const meta = {
+  title: "ArticleBody/Embeds/LinkCard",
+  component: LinkCard,
+  tags: ["autodocs"],
+} satisfies Meta<typeof LinkCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// content/ogp-cache.jsonにキャッシュがあるURL(OGP画像・説明が表示される)
+export const Cached: Story = {
+  args: {
+    url: "https://zenn.dev/ryota_09/articles/06ec306f0ef9ee",
+  },
+};
+
+// キャッシュに存在しないURL(タイトル=URLのフォールバック表示)
+export const Uncached: Story = {
+  args: {
+    url: "https://example.com/not-cached-url",
+  },
+};

--- a/src/components/ArticleBody/Embeds/LinkCard/index.tsx
+++ b/src/components/ArticleBody/Embeds/LinkCard/index.tsx
@@ -1,0 +1,60 @@
+import ExternalLink from "@/components/UiParts/ExternalLink";
+import { pickHostname } from "@/lib";
+
+import ogpCache from "../../../../../content/ogp-cache.json";
+
+type LinkCardProps = {
+  url: string;
+};
+
+type OgpCacheEntry = {
+  url: string;
+  title: string;
+  description: string | null;
+  image: string | null;
+  favicon: string | null;
+  hostname: string;
+  ok: boolean;
+};
+
+const OGP_CACHE = ogpCache as Record<string, OgpCacheEntry>;
+
+// ビルド時に静的化したOGPキャッシュ(content/ogp-cache.json、scripts/fetch-ogp-cache.mjsで生成)を
+// 参照してリンクカードを描画する。旧実装(iframely+`/[locale]/embedded` iframe)と異なり
+// 実行時fetchを行わないため、Cloudflare Workers(fsなし)でもビルド時に完結する。
+// キャッシュに無いURLは素の外部リンクカード(タイトル=URL)にフォールバックする。
+const LinkCard = ({ url }: LinkCardProps) => {
+  const cached = OGP_CACHE[url];
+  const title = cached?.title ?? url;
+  const description = cached?.description ?? undefined;
+  const image = cached?.image ?? undefined;
+  const hostname = cached?.hostname ?? pickHostname(url);
+
+  return (
+    <ExternalLink
+      href={url}
+      className="cursor-pointer transition-opacity hover:opacity-70 dark:hover:opacity-80 block my-4"
+    >
+      <aside className="flex w-full h-[90px] sm:h-[106px] md:h-[128px] lg:h-[174px] border bg-white dark:border-gray-600 dark:bg-[#333] overflow-hidden">
+        <div className="max-w-[66%] flex-1 my-1 md:my-4 px-2 md:px-6 flex flex-col justify-center">
+          <p className="dark:text-gray-300 text-md md:text-xl line-clamp-1">{title}</p>
+          {description && (
+            <p className="text-gray-500 text-sm md:mt-4 line-clamp-1 h-5">{description}</p>
+          )}
+          <p className="mt-2 md:mt-6 bg-gray-100 inline-block px-2 rounded-full text-sm md:text-md text-gray-600 line-clamp-1 w-fit">
+            {hostname}
+          </p>
+        </div>
+        {image && (
+          <figure className="w-auto max-w-[33%] flex items-center overflow-hidden shrink-0">
+            {/* NOTE: next/imageだと許可されたドメインしか表示できないため(EmbeddedCardと同じ理由) */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={image} alt={title} loading="lazy" style={{ objectFit: "cover" }} />
+          </figure>
+        )}
+      </aside>
+    </ExternalLink>
+  );
+};
+
+export default LinkCard;

--- a/src/components/ArticleBody/Embeds/MoshimoAffiliate/index.stories.tsx
+++ b/src/components/ArticleBody/Embeds/MoshimoAffiliate/index.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import MoshimoAffiliate from ".";
+
+const meta = {
+  title: "ArticleBody/Embeds/MoshimoAffiliate",
+  component: MoshimoAffiliate,
+  tags: ["autodocs"],
+} satisfies Meta<typeof MoshimoAffiliate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// content/blogs/best-buy-2026-first-half/index.ja.mdx の実データ(moshimoWidgets[0])を元にした例
+export const Default: Story = {
+  args: {
+    widget: {
+      n: "山崎実業 レンジフード調味料ラック プレート ホワイト 3128",
+      b: "Yamazaki(山崎実業)",
+      t: "3128",
+      d: "https://m.media-amazon.com",
+      c_p: "/images/I",
+      p: ["/31wYkha3ftL._SL500_.jpg"],
+      u: {
+        u: "https://www.amazon.co.jp/dp/B01CXPT43I",
+        t: "amazon",
+        r_v: "",
+      },
+      v: "2.1",
+      b_l: [
+        {
+          id: 1,
+          u_tx: "Amazonで見る",
+          u_bc: "#f79256",
+          u_url: "https://www.amazon.co.jp/dp/B01CXPT43I",
+          a_id: 2351007,
+          p_id: 170,
+          pl_id: 27060,
+          pc_id: 185,
+          s_n: "amazon",
+          u_so: 1,
+        },
+      ],
+      eid: "pjRST",
+      s: "s",
+    },
+  },
+};

--- a/src/components/ArticleBody/Embeds/MoshimoAffiliate/index.tsx
+++ b/src/components/ArticleBody/Embeds/MoshimoAffiliate/index.tsx
@@ -1,0 +1,35 @@
+import ExecutableScript from "@/components/ArticleBody/RichEditor/ExecutableScript";
+import type { MoshimoWidget } from "@/types/content";
+
+type MoshimoAffiliateProps = {
+  widget: MoshimoWidget;
+};
+
+// もしもアフィリエイト(かんたんリンク)のローダー即時関数。
+// 元のmicroCMS HTMLブロック(<!-- START MoshimoAffiliateEasyLink -->)の1つ目のscriptタグと同一。
+// bundle.jsの読み込み・msmaflink関数のキュー実装を行う。
+const MOSHIMO_LOADER_CODE = `(function(b,c,f,g,a,d,e){b.MoshimoAffiliateObject=a;
+b[a]=b[a]||function(){arguments.currentScript=c.currentScript
+||c.scripts[c.scripts.length-2];(b[a].q=b[a].q||[]).push(arguments)};
+c.getElementById(a)||(d=c.createElement(f),d.src=g,
+d.id=a,e=c.getElementsByTagName("body")[0],e.appendChild(d))})
+(window,document,"script","//dn.msmstatic.com/site/cardlink/bundle.js?20220329","msmaflink");`;
+
+// もしもアフィリエイトウィジェット(かんたんリンク)。現行のhtmlブロック(script+div)と同等のDOMを
+// MDXコンポーネントとして再構築する。scriptの実行は既存のExecutableScriptを必ず流用する
+// (React経由でDOMに挿入されたscriptタグはブラウザ仕様で実行されないため。
+//  ExecutableScriptはソフトナビゲーション対応の合成loadディスパッチを実装済み。f0b1eb5のリグレッション防止)。
+const MoshimoAffiliate = ({ widget }: MoshimoAffiliateProps) => {
+  // ウィジェットJSONのシリアライズは決定的に(JSON.stringifyはキー順を保持する)行う
+  const widgetCallCode = `msmaflink(${JSON.stringify(widget)});`;
+  const code = `${MOSHIMO_LOADER_CODE}\n${widgetCallCode}`;
+
+  return (
+    <aside className="my-4">
+      <ExecutableScript attribs={{ type: "text/javascript" }} code={code} />
+      <div id={`msmaflink-${widget.eid}`}>リンク</div>
+    </aside>
+  );
+};
+
+export default MoshimoAffiliate;

--- a/src/components/ArticleBody/Embeds/Tweet/index.stories.tsx
+++ b/src/components/ArticleBody/Embeds/Tweet/index.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Tweet from ".";
+
+// NOTE: react-tweetはTwitter/X本体への実ネットワークフェッチが必要なため、
+// Storybookのビルド環境(CIサンドボックス等)ではCORS/ネットワーク制限により
+// 正しく描画できない場合がある(既存のTwitterCardにもstoryが無いのは同様の事情による)。
+// それでもコンポーネントの疎通確認用に最小限のstoryを用意しておく。
+const meta = {
+  title: "ArticleBody/Embeds/Tweet",
+  component: Tweet,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Tweet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    id: "1921873332732825894",
+    url: "https://twitter.com/Ryo54388667/status/1921873332732825894",
+  },
+};

--- a/src/components/ArticleBody/Embeds/Tweet/index.tsx
+++ b/src/components/ArticleBody/Embeds/Tweet/index.tsx
@@ -1,0 +1,20 @@
+import { Tweet as ReactTweet } from "react-tweet";
+
+type TweetProps = {
+  id: string;
+  // MDX側の呼び出し互換のため受け取るが、react-tweetはidのみでツイートを解決するため未使用
+  url?: string;
+};
+
+// react-tweet(RSC対応)によるサーバーサイドレンダリングのツイート埋め込み。
+// ダークモードは react-tweet/theme.css が .dark 祖先クラスに自動追従するため、
+// 本コンポーネント側での明示的なテーマ切り替えは不要(src/styles/globals.cssでimport済み)。
+const Tweet = ({ id }: TweetProps) => {
+  return (
+    <aside className="max-w-[85vw] sm:max-w-[80%] md:max-w-auto sm:mx-auto overflow-x-hidden my-4 flex justify-center">
+      <ReactTweet id={id} />
+    </aside>
+  );
+};
+
+export default Tweet;

--- a/src/components/ArticleBody/MdxContent/MdxBlockquote.tsx
+++ b/src/components/ArticleBody/MdxContent/MdxBlockquote.tsx
@@ -1,0 +1,21 @@
+import { type ComponentProps } from "react";
+
+type MdxBlockquoteProps = ComponentProps<"blockquote">;
+
+// 現行(html-react-parser版)の customReplaceOptions は、blockquote直下のpタグにだけ
+// style={{ color: "#718096" }} を個別に適用していた。
+// MDXのcomponentsマップでは p コンポーネント単体から「親がblockquoteかどうか」を
+// 判定できない(親要素の情報が渡らない)ため、CSSの子孫セレクタ([&_p]:...)で同等の見た目を再現する。
+// #718096 は Tailwind の gray-500 相当の色。
+const MdxBlockquote = ({ children, ...restProps }: MdxBlockquoteProps) => {
+  return (
+    <blockquote
+      {...restProps}
+      className="border-l-4 border-gray-200 pl-2 py-1 my-2 break-all [&_p]:text-[#718096]"
+    >
+      {children}
+    </blockquote>
+  );
+};
+
+export default MdxBlockquote;

--- a/src/components/ArticleBody/MdxContent/MdxImg.tsx
+++ b/src/components/ArticleBody/MdxContent/MdxImg.tsx
@@ -1,0 +1,39 @@
+import { type ComponentProps } from "react";
+
+import CustomImg from "@/components/ArticleBody/RichEditor/CustomUI/CustomImg";
+import PopupModal from "@/components/UiParts/PopupModal";
+
+type MdxImgProps = Omit<ComponentProps<"img">, "width" | "height" | "src"> & {
+  src?: string;
+  width?: string | number;
+  height?: string | number;
+};
+
+// velite/rehype-image-size.ts がwidth/height属性を注入済みの前提で描画する。
+// 何らかの理由で注入できなかった画像(ソース解決失敗等)はwidth/height無しのフォールバックとして
+// 素のimgタグで描画する(現行のReplaceUiParts.lib.tsxのimgケースと同じフォールバック方針)。
+//
+// NOTE(現行との意図的な差異): 現行は「親要素がaタグの場合はPopupModalでラップしない」という
+// 判定を行っていたが、MDXのcomponentsマップはimg単体では親要素を判定できない。
+// 変換済みMDX内でリンク内画像を使っている実例(release-notes-202407)のリンク先はダミーURLで
+// 実質的にリンクとして機能していないため、影響は軽微と判断し常時PopupModalでラップする。
+const MdxImg = ({ src, alt, width, height, ...restProps }: MdxImgProps) => {
+  if (!src || !width || !height) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={alt ?? ""} {...restProps} />;
+  }
+
+  return (
+    <PopupModal>
+      <CustomImg
+        {...restProps}
+        src={src}
+        alt={alt ?? ""}
+        width={String(width)}
+        height={String(height)}
+      />
+    </PopupModal>
+  );
+};
+
+export default MdxImg;

--- a/src/components/ArticleBody/MdxContent/MdxLink.tsx
+++ b/src/components/ArticleBody/MdxContent/MdxLink.tsx
@@ -1,0 +1,36 @@
+import { type ComponentProps } from "react";
+
+import CustomLink from "@/components/ArticleBody/RichEditor/CustomUI/CustomLink";
+import ExternalLink from "@/components/UiParts/ExternalLink";
+
+type MdxLinkProps = ComponentProps<"a">;
+
+// 現行(ReplaceUiParts.lib.tsxのaケース)と同じ内部/外部判定ロジックをそのまま踏襲する:
+// httpで始まる、またはtarget=_blank、またはURLにamazonを含む場合は外部リンク扱い。
+const MdxLink = ({ href, children, ...restProps }: MdxLinkProps) => {
+  const resolvedHref = href ?? "";
+  const isExternal =
+    resolvedHref.startsWith("http") ||
+    restProps.target === "_blank" ||
+    resolvedHref.includes("amazon");
+
+  if (isExternal) {
+    return (
+      <ExternalLink
+        {...restProps}
+        href={resolvedHref}
+        className="underline underline-offset-4 transition hover:text-base-color dark:hover:text-primary hover:no-underline break-all"
+      >
+        {children}
+      </ExternalLink>
+    );
+  }
+
+  return (
+    <CustomLink {...restProps} href={resolvedHref}>
+      {children}
+    </CustomLink>
+  );
+};
+
+export default MdxLink;

--- a/src/components/ArticleBody/MdxContent/MdxPre.tsx
+++ b/src/components/ArticleBody/MdxContent/MdxPre.tsx
@@ -1,0 +1,44 @@
+import { isValidElement, type ComponentProps } from "react";
+
+import MultiCodeBlock from "@/components/ArticleBody/RichEditor/Code/MultiCodeBlock";
+
+type MdxPreProps = ComponentProps<"pre">;
+
+type CodeElementProps = {
+  className?: string;
+  children?: string;
+  "data-meta"?: string;
+};
+
+// fenced code(```lang title="filename"```)のdata-metaから title="..." の値を取り出す。
+// velite/rehype-code-meta.ts がcode要素の properties["data-meta"] にmeta文字列をコピー済みの前提。
+const extractFilename = (meta: string | undefined): string | null => {
+  if (!meta) return null;
+  const match = meta.match(/title="([^"]*)"/);
+  return match ? match[1] : null;
+};
+
+// MDXの pre > code 構造をMultiCodeBlock(既存のシンタックスハイライトコンポーネント)へ橋渡しする。
+// 現行(ReplaceUiParts.lib.tsxのpreケース)と同じくlanguage-xクラスからlangを、
+// data-filename(旧)相当のtitle="..."からfilenameを抽出する。
+const MdxPre = ({ children, ...restProps }: MdxPreProps) => {
+  const codeElement = isValidElement<CodeElementProps>(children) ? children : null;
+
+  if (!codeElement) {
+    return <pre {...restProps}>{children}</pre>;
+  }
+
+  const codeProps = codeElement.props;
+  const className = codeProps.className ?? "";
+  const langMatch = className.match(/language-(\S+)/);
+  const lang = langMatch ? langMatch[1] : "";
+  const filename = extractFilename(codeProps["data-meta"]);
+
+  return (
+    <MultiCodeBlock filename={filename} lang={lang}>
+      {codeProps.children ?? ""}
+    </MultiCodeBlock>
+  );
+};
+
+export default MdxPre;

--- a/src/components/ArticleBody/MdxContent/index.tsx
+++ b/src/components/ArticleBody/MdxContent/index.tsx
@@ -1,0 +1,41 @@
+import * as runtime from "react/jsx-runtime";
+
+import type { BlogPost } from "@/types/content";
+
+import { makeMdxComponents } from "./makeMdxComponents";
+
+type MdxContentProps = {
+  blog: BlogPost;
+};
+
+// キャッシュ: 同一のbody文字列を毎回 `new Function` で評価し直すのは無駄なコストがかかるため、
+// コンパイル結果(関数)をモジュールスコープでキャッシュする。
+// (bodyはビルド時に確定する文字列であり、同一プロセス内で内容が変わることはない)
+const compiledFunctionCache = new Map<string, (arg: unknown) => { default: React.ComponentType<Record<string, unknown>> }>();
+
+const getMdxModule = (body: string) => {
+  const cached = compiledFunctionCache.get(body);
+  if (cached) return cached;
+
+  // Velite公式のfunction-body評価方式。s.mdx()の出力(outputFormat: "function-body")は
+  // 関数本体の文字列であり、new Functionで実行可能な関数へ変換したうえでjsx-runtimeを渡して呼び出す。
+  const fn = new Function(body) as (arg: unknown) => {
+    default: React.ComponentType<Record<string, unknown>>;
+  };
+  compiledFunctionCache.set(body, fn);
+  return fn;
+};
+
+// Veliteが生成したMDX(function-body文字列)を評価してレンダリングするコンポーネント。
+// components マップは ReplaceUiParts.lib.tsx (旧HTML→React変換)のマッピングをMDX向けに
+// 再現したもの(makeMdxComponents.tsx参照)。すべてビルド時に確定したbody文字列を評価するだけで、
+// ネットワークアクセスやNode.js固有API(fs等)には依存しないためCloudflare Workers上でも動作する。
+const MdxContent = ({ blog }: MdxContentProps) => {
+  const mdxModule = getMdxModule(blog.body)({ ...runtime, Fragment: runtime.Fragment });
+  const Content = mdxModule.default;
+  const components = makeMdxComponents(blog);
+
+  return <Content components={components} />;
+};
+
+export default MdxContent;

--- a/src/components/ArticleBody/MdxContent/makeMdxComponents.tsx
+++ b/src/components/ArticleBody/MdxContent/makeMdxComponents.tsx
@@ -1,0 +1,76 @@
+import type { ComponentProps } from "react";
+
+import CustomH2 from "@/components/ArticleBody/RichEditor/CustomUI/CustomH2";
+import CustomH3 from "@/components/ArticleBody/RichEditor/CustomUI/CustomH3";
+import CustomParagraph from "@/components/ArticleBody/RichEditor/CustomUI/CustomParagraph";
+import CustomStrong from "@/components/ArticleBody/RichEditor/CustomUI/CustomStrong";
+import CustomU from "@/components/ArticleBody/RichEditor/CustomUI/CustomU";
+import CustomUl from "@/components/ArticleBody/RichEditor/CustomUI/CustomUl";
+import CustomLi from "@/components/ArticleBody/RichEditor/CustomUI/CustomLi";
+import CustomCode from "@/components/ArticleBody/RichEditor/CustomUI/CustomCode";
+import CustomTable from "@/components/ArticleBody/RichEditor/CustomUI/Table/CustomTable";
+import CustomTbody from "@/components/ArticleBody/RichEditor/CustomUI/Table/CustomTbody";
+import CustomTr from "@/components/ArticleBody/RichEditor/CustomUI/Table/CustomTr";
+import CustomTh from "@/components/ArticleBody/RichEditor/CustomUI/Table/CustomTh";
+import CustomTd from "@/components/ArticleBody/RichEditor/CustomUI/Table/CustomTd";
+
+import Tweet from "@/components/ArticleBody/Embeds/Tweet";
+import LinkCard from "@/components/ArticleBody/Embeds/LinkCard";
+import AmazonLink from "@/components/ArticleBody/Embeds/AmazonLink";
+import MoshimoAffiliate from "@/components/ArticleBody/Embeds/MoshimoAffiliate";
+import Copyable from "@/components/ArticleBody/Embeds/Copyable";
+
+import type { BlogPost } from "@/types/content";
+
+import MdxBlockquote from "./MdxBlockquote";
+import MdxLink from "./MdxLink";
+import MdxImg from "./MdxImg";
+import MdxPre from "./MdxPre";
+
+// MoshimoAffiliateのidから対応するウィジェットを解決するために、MDXコンポーネントマップは
+// 記事(blog)ごとにファクトリで生成する必要がある(MoshimoAffiliateはprops.idしか受け取らないため、
+// blog.moshimoWidgets配列をここで束縛して解決する)。
+export const makeMdxComponents = (blog: Pick<BlogPost, "moshimoWidgets">) => {
+  return {
+    // 見出し: h2/h3のみ現行の特別扱いを踏襲する(h4以下は素のタグ。現行も特別扱いなし)
+    h2: CustomH2,
+    h3: CustomH3,
+    p: CustomParagraph,
+    strong: CustomStrong,
+    u: CustomU,
+    ul: CustomUl,
+    li: CustomLi,
+    // ol: 現行も特別扱いなし(素のol)。ulとの対比で見た目がずれないよう最低限のインデントは付与する
+    ol: (props: ComponentProps<"ol">) => <ol {...props} className="px-8 my-4 list-decimal" />,
+    blockquote: MdxBlockquote,
+    a: MdxLink,
+    img: MdxImg,
+    pre: MdxPre,
+    code: (props: ComponentProps<"code">) => (
+      <CustomCode
+        {...props}
+        className="bg-gray-200 dark:bg-gray-400 font-mono text-sm dark:text-gray-700 px-1 py-0.5 rounded"
+      />
+    ),
+    table: CustomTable,
+    // theadに対応するCustom実装は現行に存在しないため素のtheadを使う(GFMテーブルがthead/thを生成するため必要)
+    thead: (props: ComponentProps<"thead">) => <thead {...props} />,
+    tbody: CustomTbody,
+    tr: CustomTr,
+    th: CustomTh,
+    td: CustomTd,
+    br: (props: ComponentProps<"br">) => <br {...props} />,
+    // 埋め込みコンポーネント
+    Tweet,
+    LinkCard,
+    AmazonLink,
+    MoshimoAffiliate: ({ id }: { id: string }) => {
+      const widget = blog.moshimoWidgets[Number(id)];
+      if (!widget) return null;
+      return <MoshimoAffiliate widget={widget} />;
+    },
+    Copyable,
+  };
+};
+
+export type MdxComponents = ReturnType<typeof makeMdxComponents>;

--- a/src/components/ArticleBody/PrevAndNextBlogNav/PrevAndNextNavItem/index.tsx
+++ b/src/components/ArticleBody/PrevAndNextBlogNav/PrevAndNextNavItem/index.tsx
@@ -3,23 +3,23 @@
 import { Link } from "next-view-transitions";
 import { useLocale, useTranslations } from 'next-intl';
 
-import type { BlogsContentType } from "@/types/microcms";
+import type { BlogPost } from "@/types/content";
 import { cltw } from "@/util";
-import { getPrimaryCategoryId } from "@/lib";
+import { getPrimaryCategoryIdFromBlogPost } from "@/lib/content";
 
 type PrevAndNextBlogNavItemProps = {
   role: "prev" | "next"
-  data: Pick<BlogsContentType, "id" | "title" | "publishedAt" | "updatedAt" | "category">
+  data: Pick<BlogPost, "slug" | "title" | "publishedAt" | "updatedAt" | "categories">
 }
 
 const PrevAndNextBlogNavItem = ({ role, data }: PrevAndNextBlogNavItemProps) => {
   const locale = useLocale();
   const t = useTranslations('blog');
   const displayTime = data.publishedAt || data.updatedAt;
-  const categoryId = getPrimaryCategoryId(data);
-  
+  const categoryId = getPrimaryCategoryIdFromBlogPost(data);
+
   return (
-    <Link href={`/${locale}/blogs/${categoryId}/${data.id}`} className={cltw("max-w-1/2 py-4 transition text-gray-400 dark:text-gray-500 underline underline-offset-4 hover:opacity-70 hover:text-base-color hover:no-underline", role === "prev" ? "text-left" : "text-right")}>
+    <Link href={`/${locale}/blogs/${categoryId}/${data.slug}`} className={cltw("max-w-1/2 py-4 transition text-gray-400 dark:text-gray-500 underline underline-offset-4 hover:opacity-70 hover:text-base-color hover:no-underline", role === "prev" ? "text-left" : "text-right")}>
       <span>{role === "prev" ? t('previousArticle') : t('nextArticle')}</span><br className="inline sm:hidden" />
       <time dateTime={displayTime.split('T')[0]}>({displayTime.split('T')[0]})</time><br />
       <span className="line-clamp-2 sm:line-clamp-1">{data.title}</span>

--- a/src/components/ArticleBody/PrevAndNextBlogNav/index.tsx
+++ b/src/components/ArticleBody/PrevAndNextBlogNav/index.tsx
@@ -1,14 +1,16 @@
 import PrevAndNextBlogNavItem from "@/components/ArticleBody/PrevAndNextBlogNav/PrevAndNextNavItem";
-import { getPrevAndNextBlogByLocale } from "@/lib/microcms";
-import type { BlogsContentType } from "@/types/microcms";
+import { getPrevAndNextBlogByLocale } from "@/lib/content";
+import type { BlogPost, ContentLocale } from "@/types/content";
 
 type PrevAndNextBlogNavProps = {
-  currentBlogData: BlogsContentType
-  locale: string
+  currentBlogData: Pick<BlogPost, "publishedAt">
+  locale: ContentLocale
 }
 
-const PrevAndNextBlogNav = async ({ currentBlogData, locale }: PrevAndNextBlogNavProps) => {
-  const { prevBlogData, nextBlogData } = await getPrevAndNextBlogByLocale(locale, currentBlogData);
+// content.tsのgetPrevAndNextBlogByLocaleは同期関数(Velite由来のインメモリ配列を走査するだけ)のため、
+// 非同期(microCMS API呼び出し)だった現行版と異なりasyncは不要
+const PrevAndNextBlogNav = ({ currentBlogData, locale }: PrevAndNextBlogNavProps) => {
+  const { prevBlogData, nextBlogData } = getPrevAndNextBlogByLocale(locale, currentBlogData);
   return (
     <nav className="mt-4 grid grid-cols-2 divide-x-4 divide-white dark:divide-black">
       {prevBlogData ? <PrevAndNextBlogNavItem role="prev" data={prevBlogData} /> : <div className="max-w-1/2 py-4" />}

--- a/src/components/ArticleBody/index.tsx
+++ b/src/components/ArticleBody/index.tsx
@@ -1,11 +1,11 @@
 import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton";
 
-import RichEditor from "@/components/ArticleBody/RichEditor";
 import ThumbnailCard from '@/components/ArticleBody/ThumbnailCard';
 import BottomCard from '@/components/ArticleBody/BottomCard';
 import FixedButton from '@/components/UiParts/FixedButton';
-import { BlogsContentType } from '@/types/microcms';
-import { generateTOCAssets, getPrimaryCategoryId, buildPageUrl } from "@/lib";
+import type { BlogPost, ContentLocale } from '@/types/content';
+import { buildPageUrl } from "@/lib";
+import { getPrimaryCategoryIdFromBlogPost, buildTocAssets } from "@/lib/content";
 import TOCList from "@/components/ArticleBody/TOCList";
 import AdRevenueLabel from "@/components/AdRevenueLabel";
 import PrevAndNextBlogNav from "@/components/ArticleBody/PrevAndNextBlogNav";
@@ -14,27 +14,18 @@ import { calcDiffYears } from "@/util";
 import InfoYearsCard from "@/components/UiParts/InfoYearsCard";
 import CategoryTag from "./CategoryTag";
 import LocaleAwareShare from "./LocaleAwareShare";
-// Next.js 16では、Client Componentに対してssr: falseを使用できない
-// 各コンポーネントは"use client"でマークされているため、通常のimportに変更
-import HTMLArea from '@/components/ArticleBody/RichEditor/HTMLArea';
-import AmazonLinkCard from '@/components/ArticleBody/RichEditor/AmazonLinkCard';
+import MdxContent from "@/components/ArticleBody/MdxContent";
 
 type ArticleBodyProps = {
-  data: BlogsContentType
-  locale: string
+  data: BlogPost
+  locale: ContentLocale
 }
 
 const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
-  const joindedHTML = data.body.map((body) => {
-    if (body.fieldId === 'richEditor') {
-      return body.richEditor
-    }
-  }).join('')
-
   const displayTime = data.publishedAt || data.updatedAt
-  const categoryId = getPrimaryCategoryId(data);
+  const categoryId = getPrimaryCategoryIdFromBlogPost(data);
+  const tocData = buildTocAssets(data.toc);
 
-  const TOCdata = generateTOCAssets(joindedHTML)
   return (
     <div>
       <div className='md:w-[80%] mx-auto my-6 md:my-16'>
@@ -44,7 +35,7 @@ const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
             <h1 className="text-2xl md:text-3xl font-bold dark:text-gray-300">{data.title}</h1>
             <figure className="relative max-h-[300px] md:max-h-[540px] overflow-hidden shadow-2xl">
               <ImageWithSkeleton
-                src={data.thumbnail.url}
+                src={data.thumbnail.src}
                 alt={data.title}
                 width={data.thumbnail.width}
                 height={data.thumbnail.height}
@@ -53,7 +44,7 @@ const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
                   height: "auto",
                   width: "100%",
                   // 記事一覧のサムネイル画像と同じ名前を付け、遷移直後にサムネイルがそのままモーフするようにする
-                  viewTransitionName: `thumb-${data.id}`,
+                  viewTransitionName: `thumb-${data.slug}`,
                 }}
                 loading="eager"
                 preload
@@ -73,12 +64,12 @@ const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
         </aside>
       )}
       <ul className='mt-4 flex flex-wrap gap-2'>
-        {data.category.map(({ id }, index) => (
-          <CategoryTag key={index} id={id} index={index} />
+        {data.categories.map((id, index) => (
+          <CategoryTag key={id} id={id} index={index} />
         ))}
       </ul>
       <div className="mt-4">
-        <TOCList data={TOCdata} />
+        <TOCList data={tocData} />
       </div>
       {data.isAdvertisement && (
         <aside className="mt-4">
@@ -86,26 +77,15 @@ const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
         </aside>
       )}
       <div className='my-12'>
-        {data.body.map((body, index) => {
-          switch (body.fieldId) {
-            case "richEditor":
-              return <RichEditor key={index} html={body.richEditor} />
-            case "html":
-              const html = body.html
-              if (html.startsWith('AMAZON')) {
-                return <AmazonLinkCard key={index} html={html.replace("AMAZON", "")} />
-              }
-              return <HTMLArea key={index} html={html} />
-          }
-        })}
+        <MdxContent blog={data} />
       </div>
-        <IssueButton currentPath={buildPageUrl(locale, "blogs", categoryId, data.id)} />
+        <IssueButton currentPath={buildPageUrl(locale, "blogs", categoryId, data.slug)} />
         <PrevAndNextBlogNav currentBlogData={data} locale={locale} />
         <aside className='flex flex-col-reverse md:flex-row gap-8 md:gap-4 mx-0.5 border-t dark:border-t-[#333] py-10'>
           <BottomCard />
         </aside>
         <FixedButton />
-        <LocaleAwareShare categoryId={categoryId} blogId={data.id} title={data.title} />
+        <LocaleAwareShare categoryId={categoryId} blogId={data.slug} title={data.title} />
     </div>
   )
 }

--- a/src/components/Head/JsonLD/index.tsx
+++ b/src/components/Head/JsonLD/index.tsx
@@ -1,22 +1,24 @@
 import type { BreadcrumbList, BlogPosting, WithContext, WebSite } from "schema-dts"
-import type { BlogsContentType } from "@/types/microcms"
+import type { BlogPost } from "@/types/content"
 import { SITE_TITLE } from "@/static/blogs"
 import { findCategoryBySlug } from "@/static/categories"
-import { getPrimaryCategoryId, buildPageUrl } from "@/lib"
+import { buildPageUrl } from "@/lib"
+import { getPrimaryCategoryIdFromBlogPost } from "@/lib/content"
 import { getLocalizedCategoryName } from "@/lib/i18n-utils"
+import { baseURL } from "@/config"
 
 
 type JsonLDProps = {
-  data: BlogsContentType
+  data: BlogPost
   locale: string
 }
 
 const JsonLD = ({ data, locale }: JsonLDProps) => {
-  const categoryId = getPrimaryCategoryId(data);
+  const categoryId = getPrimaryCategoryIdFromBlogPost(data);
   const categoryEntry = findCategoryBySlug(categoryId);
   const categoryName = categoryEntry ? getLocalizedCategoryName(categoryEntry, locale) : categoryId;
   // 構造化データのURLは実ルーティング（/[locale]/blogs/...）に合わせて locale 込みで構築する
-  const articleUrl = buildPageUrl(locale, "blogs", categoryId, data.id);
+  const articleUrl = buildPageUrl(locale, "blogs", categoryId, data.slug);
   const authorUrl = buildPageUrl(locale, "about");
 
   const breadcrumbJsonLD: WithContext<BreadcrumbList> = {
@@ -54,9 +56,16 @@ const JsonLD = ({ data, locale }: JsonLDProps) => {
     headline: data.title,
     datePublished: data.publishedAt || data.updatedAt,
     dateModified: data.updatedAt,
-    keywords: [...data.category.map(({ name }) => name), data.title].join(","),
+    keywords: [
+      ...data.categories.map((slug) => {
+        const entry = findCategoryBySlug(slug);
+        return entry ? getLocalizedCategoryName(entry, locale) : slug;
+      }),
+      data.title,
+    ].join(","),
     description: data.description,
-    image: data.thumbnail?.url,
+    // thumbnail.srcはVeliteが生成する `/static/...` のサイト内相対パスのため、絶対URL化して埋め込む
+    image: data.thumbnail ? `${baseURL}${data.thumbnail.src}` : undefined,
     author: {
       "@type": "Person",
       name: "Ryota",

--- a/src/components/RelatedContentList/RelatedContentItem/index.tsx
+++ b/src/components/RelatedContentList/RelatedContentItem/index.tsx
@@ -3,7 +3,6 @@
 import Chip from "@/components/UiParts/Chip";
 import { getLocalizedCategoryName } from "@/lib/i18n-utils";
 import { resolveCategoryOrDefault } from "@/static/categories";
-import { CategoriesContentType } from "@/types/microcms";
 import { Link } from "next-view-transitions";
 import { useLocale } from 'next-intl';
 
@@ -11,14 +10,15 @@ type RelatedContentItemProps = {
   id: string;
   updatedAt: string;
   title: string;
-  category: Pick<CategoriesContentType, "id">[];
+  // BlogPost.categories相当(カテゴリslugの配列。先頭がプライマリ)
+  categories: string[];
   publishedAt?: string;
 }
 
-const RelatedContentItem = ({ id, publishedAt, updatedAt, title, category }: RelatedContentItemProps) => {
+const RelatedContentItem = ({ id, publishedAt, updatedAt, title, categories }: RelatedContentItemProps) => {
   const locale = useLocale();
   const displayTime = publishedAt || updatedAt;
-  const primaryCategoryId = resolveCategoryOrDefault(category[0]?.id).slug;
+  const primaryCategoryId = resolveCategoryOrDefault(categories[0]).slug;
 
   return (
     <li>
@@ -28,7 +28,7 @@ const RelatedContentItem = ({ id, publishedAt, updatedAt, title, category }: Rel
           <p className="line-clamp-2 md:line-clamp-3 text-txt-base dark:text-gray-300 group-hover:underline group-hover:underline-offset-4 group-hover:decoration-txt-base dark:group-hover:decoration-gray-300">{title}</p>
         </div>
         <ul className="flex flex-wrap items-center gap-1 w-full md:w-auto justify-end">
-          {category.map(({ id: categoryId }) => {
+          {categories.map((categoryId) => {
             const entry = resolveCategoryOrDefault(categoryId);
             return (
               <li key={categoryId}>

--- a/src/components/RelatedContentList/index.stories.tsx
+++ b/src/components/RelatedContentList/index.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import RelatedContentList from ".";
-import type { BlogsContentType } from "@/types/microcms";
 
 const meta = {
   title: 'Components/RelatedContentList',
@@ -16,54 +15,12 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const data: BlogsContentType = {
-  "id": "customdomain-apprunner-with-terraform-route53",
-  "createdAt": "2024-06-14T05:36:56.274Z",
-  "updatedAt": "2024-06-15T04:26:30.883Z",
-  "publishedAt": new Date().toString(),
-  "revisedAt": "2024-06-15T04:26:30.883Z",
-  "title": "タイトルテキストタイトルテキストタイトルテキストタイトルテキストタイトルテキスト",
-  "body": [
-    {
-      "fieldId": "richEditor",
-      "richEditor": ""
-    }
-  ],
-  "description": "今回は〇〇する方法を紹介していきます！今回は〇〇する方法を紹介していきます！今回は〇〇する方法を紹介していきます！今回は〇〇する方法を紹介していきます！",
-  "noIndex": false,
-  "isAdvertisement": false,
-  "thumbnail": {
-    "url": "./no_contents.png",
-    "height": 1080,
-    "width": 1920
-  },
-  "category": [
-    {
-      "id": "aws",
-      "createdAt": "2024-05-25T05:31:41.218Z",
-      "updatedAt": "2024-05-25T07:13:41.932Z",
-      "publishedAt": "2024-05-25T05:31:41.218Z",
-      "revisedAt": "2024-05-25T05:31:41.218Z",
-      "name": "AWS"
-    },
-    {
-      "id": "terraform",
-      "createdAt": "2024-06-14T05:40:43.012Z",
-      "updatedAt": "2024-06-14T06:08:40.759Z",
-      "publishedAt": "2024-06-14T05:40:43.012Z",
-      "revisedAt": "2024-06-14T05:40:43.012Z",
-      "name": "Terraform"
-    },
-    {
-      "id": "terraform",
-      "createdAt": "2024-06-14T05:40:43.012Z",
-      "updatedAt": "2024-06-14T06:08:40.759Z",
-      "publishedAt": "2024-06-14T05:40:43.012Z",
-      "revisedAt": "2024-06-14T05:40:43.012Z",
-      "name": "Next.js"
-    },
-  ],
-  "relatedContent": []
+const data = {
+  slug: "customdomain-apprunner-with-terraform-route53",
+  updatedAt: "2024-06-15T04:26:30.883Z",
+  publishedAt: new Date().toISOString(),
+  title: "タイトルテキストタイトルテキストタイトルテキストタイトルテキストタイトルテキスト",
+  categories: ["aws", "terraform", "next_js"],
 }
 
 export const Default: Story = {

--- a/src/components/RelatedContentList/index.tsx
+++ b/src/components/RelatedContentList/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 import { useTranslations } from 'next-intl';
 import RelatedContentItem from "@/components/RelatedContentList/RelatedContentItem";
-import { BlogsContentType } from "@/types/microcms";
+import type { BlogPost } from "@/types/content";
 
 type RelatedContentProps = {
-  data: BlogsContentType[]
+  data: Pick<BlogPost, "slug" | "publishedAt" | "updatedAt" | "title" | "categories">[]
 }
 
 const RelatedContentList = ({ data }: RelatedContentProps) => {
@@ -14,8 +14,8 @@ const RelatedContentList = ({ data }: RelatedContentProps) => {
     <>
       <div className="text-2xl dark:text-gray-300 font-bold mb-4">{t('relatedPosts')}</div>
       <ul className="divide-y">
-        {data.map(({ id, publishedAt, updatedAt, title, category }) => (
-          <RelatedContentItem key={id} id={id} publishedAt={publishedAt} updatedAt={updatedAt} title={title} category={category} />
+        {data.map(({ slug, publishedAt, updatedAt, title, categories }) => (
+          <RelatedContentItem key={slug} id={slug} publishedAt={publishedAt} updatedAt={updatedAt} title={title} categories={categories} />
         ))}
       </ul>
     </>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,9 +1,13 @@
 // Velite(content/配下のMDX/JSON)を情報源とするコンテンツ取得層。
 // 既存の src/lib/microcms.ts と同等のセマンティクスを持つ関数群を提供する。
-// #235時点では新設のみ行い、既存ページ・コンポーネントの置き換えは行わない(#236/#238/#239で対応)。
+// #236で記事詳細ページ(src/app/[locale]/blogs/[category]/[blogId]/page.tsx)をこの層に切り替えた。
 import { cache } from "react";
+import { getTranslations } from "next-intl/server";
 
 import { blogs as ALL_BLOGS } from "#content/index";
+import { resolveCategoryOrDefault } from "@/static/categories";
+import { getLocalizedCategoryName } from "@/lib/i18n-utils";
+import type { BreadcrumbItemType, TOCAssetsType } from "@/types";
 import type {
   BlogListQuery,
   BlogListResult,
@@ -119,4 +123,71 @@ export const getPrevAndNextBlogByLocale = (
     null;
 
   return { prevBlogData, nextBlogData };
+};
+
+/**
+ * getPrimaryCategoryId(src/lib/index.ts)のBlogPost版。
+ * BlogPost.categoriesは文字列配列(slug)なので、BlogsContentType版のように category[0].id を
+ * 取り出す必要はなく、先頭要素をそのままresolveCategoryOrDefaultに渡すだけでよい。
+ */
+export const getPrimaryCategoryIdFromBlogPost = (blog: Pick<BlogPost, "categories">): string => {
+  return resolveCategoryOrDefault(blog.categories[0]).slug;
+};
+
+/**
+ * BlogPost.toc(文書順のフラット配列: {depth, text, id}[])を、
+ * TOCList(src/components/ArticleBody/TOCList)が期待するネスト形状(TOCAssetsType[])に変換する。
+ * 現行のgenerateTOCAssets(depth2をトップレベル、depth3をsubListにネスト)と同じ構造にする。
+ * id が null の見出し(headingIdsが見出し数より少ない場合)はTOC自体から除外する
+ * (TOCListはidをキー・アンカーリンク先として必須で使うため)。
+ */
+export const buildTocAssets = (toc: BlogPost["toc"]): TOCAssetsType[] => {
+  const results: TOCAssetsType[] = [];
+
+  for (const entry of toc) {
+    if (!entry.id) continue;
+
+    if (entry.depth === 2) {
+      results.push({ id: entry.id, text: entry.text, subList: [] });
+    } else if (entry.depth === 3 && results.length > 0) {
+      results[results.length - 1].subList.push({ id: entry.id, text: entry.text });
+    }
+  }
+
+  return results;
+};
+
+/**
+ * BlogPost.related(slug配列)から、実在する関連記事(BlogPost[])を解決する。
+ * 現行のrelatedContent(microCMSのリレーションフィールド)相当。
+ * 存在しないslug(記事削除等)は黙って除外する。
+ */
+export const resolveRelatedBlogs = (locale: ContentLocale, related: string[]): BlogPost[] => {
+  const blogs = getPublishedBlogsByLocale(locale);
+  return related
+    .map((slug) => blogs.find((blog) => blog.slug === slug))
+    .filter((blog): blog is BlogPost => blog !== undefined);
+};
+
+/**
+ * generateBreadcrumbAssets(src/lib/index.ts)のBlogPost版。パンくずリストの3階層
+ * (ホーム/カテゴリ/記事タイトル)を生成する。ロジックはBlogsContentType版と同一で、
+ * カテゴリ解決とタイトル・スラッグの取り出し元をBlogPostの形状に合わせただけ。
+ */
+export const generateBreadcrumbAssetsFromBlogPost = async (
+  blog: Pick<BlogPost, "categories" | "title" | "slug">,
+  locale: ContentLocale = "ja",
+): Promise<BreadcrumbItemType[]> => {
+  const categoryEntry = resolveCategoryOrDefault(blog.categories[0]);
+  const categoryId = categoryEntry.slug;
+  const t = await getTranslations({ locale, namespace: "navigation" });
+
+  const categoryName = getLocalizedCategoryName(categoryEntry, locale);
+  const localePrefix = `/${locale}`;
+
+  return [
+    { label: t("home"), href: localePrefix },
+    { label: categoryName, href: `${localePrefix}/blogs/${categoryId}` },
+    { label: blog.title, href: `${localePrefix}/blogs/${categoryId}/${blog.slug}` },
+  ];
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,7 @@
 /* NOTE: ファイルのトップに記述 */
 @import './custom.css';
+/* react-tweet(#236): .dark祖先クラス(既存のdarkMode: "class"機構)に自動追従するテーマCSS */
+@import 'react-tweet/theme.css';
 
 @tailwind base;
 @tailwind components;

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -8,6 +8,13 @@ import type { Blogs, Categories } from "#content/index";
 //  headingIds/moshimoWidgets/body/raw/slug/locale/toc/plainText を含む)
 export type BlogPost = Blogs;
 
+// もしもアフィリエイトウィジェット1件分の型(MoshimoAffiliateコンポーネントのprops用)。
+// フィールド名の意味はvelite.config.tsのmoshimoWidgetSchemaコメントを参照。
+export type MoshimoWidget = BlogPost["moshimoWidgets"][number];
+
+// TOCエントリ(velite/mdast-utils.tsのextractTocが生成する形状)。
+export type TocEntry = BlogPost["toc"][number];
+
 // Veliteが生成するカテゴリコレクションの型をそのまま公開する。
 export type Category = Categories;
 

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -9,6 +9,9 @@ import path from "node:path";
 import { context, defineCollection, defineConfig, s } from "velite";
 
 import { extractPlainText, extractToc } from "./velite/mdast-utils";
+import { rehypeCodeMeta } from "./velite/rehype-code-meta";
+import { rehypeImageSize } from "./velite/rehype-image-size";
+import { rehypeRestoreHeadingIds } from "./velite/rehype-restore-heading-ids";
 
 // 現在パース中のファイルのパス(blogs/{slug}/index.{locale}.mdx)から slug と locale を抽出する
 // (VeliteFile.pathはconfig.rootからの絶対パスのため、まずroot相対パスに正規化してから照合する)
@@ -116,7 +119,11 @@ const categories = defineCollection({
 export default defineConfig({
   collections: { blogs, categories },
   mdx: {
-    // 現時点ではremark/rehypeプラグインは追加しない(見出しid注入・embedコンポーネント対応は#236で行う)
+    // 見出しid復元・画像サイズ注入・codeメタ受け渡し(#236)。
+    // 実行順序: rehypePluginsはremark段階(remarkCopyLinkedFiles含む)より後に実行されるため、
+    // rehypeImageSizeは画像パスが/static/...へ書き換わった後の状態で実ファイルを解決する
+    // (詳細はvelite/rehype-image-size.tsのコメント参照)。
+    rehypePlugins: [rehypeRestoreHeadingIds, rehypeImageSize, rehypeCodeMeta],
   },
   complete: (data, { config }) => {
     // middleware.ts の旧URL(/blogs/{slug})リダイレクト用に、

--- a/velite/read-frontmatter.ts
+++ b/velite/read-frontmatter.ts
@@ -1,0 +1,37 @@
+// rehypeプラグインからfrontmatterを取得するための共通ユーティリティ。
+//
+// なぜ必要か:
+// velite の s.mdx() は `compile({ value, path: meta.path }, ...)` という形で
+// 「frontmatterを除いた本文(value)」と「元ファイルの絶対パス(path)」だけをMDXコンパイラに渡す。
+// rehype/remarkプラグインが受け取る vfile(file引数) には file.data にfrontmatterは載らない
+// (実機検証済み: file.data は常に {} )。
+// そのため、file.path から元のMDXファイルをfsで直接読み直し、frontmatterをパースする。
+// ビルド時(Node.js環境)にのみ実行されるため fs アクセスは問題ない(本番Cloudflare Workersでは実行されない)。
+import { readFileSync } from "node:fs";
+
+import yaml from "js-yaml";
+
+// 同一ファイルへの複数回アクセス(remark/rehype複数プラグインからの呼び出し)に備え、
+// パース結果をモジュール内でキャッシュする
+const frontmatterCache = new Map<string, Record<string, unknown>>();
+
+// `---\n...\n---` のYAMLフロントマターブロックを抽出する正規表現
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+// 指定したMDXファイルパスからfrontmatterをパースして返す。frontmatterが無い場合は空オブジェクト。
+export const readFrontmatter = (filePath: string): Record<string, unknown> => {
+  const cached = frontmatterCache.get(filePath);
+  if (cached) return cached;
+
+  const raw = readFileSync(filePath, "utf-8");
+  const match = raw.match(FRONTMATTER_PATTERN);
+  if (!match) {
+    frontmatterCache.set(filePath, {});
+    return {};
+  }
+
+  const parsed = yaml.load(match[1]);
+  const result = (parsed ?? {}) as Record<string, unknown>;
+  frontmatterCache.set(filePath, result);
+  return result;
+};

--- a/velite/rehype-code-meta.ts
+++ b/velite/rehype-code-meta.ts
@@ -1,0 +1,22 @@
+// フェンスドコードブロックの meta 文字列(例: ```bash title="terminal" の title="terminal" 部分)を
+// code要素の properties["data-meta"] にコピーするrehypeプラグイン。
+//
+// なぜ必要か:
+// mdast-util-to-hast(MDXが内部で使うmdast→hast変換)は、コードのmeta文字列を
+// hastノードの `data.meta` に保持するのみで、`properties`(=JSXのprops)にはコピーしない。
+// MDXの components マップ(pre/code)はJSXのpropsしか参照できないため、
+// このプラグインで明示的に data-meta プロパティへコピーし、MdxContent側の
+// pre コンポーネントから `props.children.props["data-meta"]` として参照できるようにする。
+import { visit } from "unist-util-visit";
+import type { Root, Element } from "hast";
+
+export const rehypeCodeMeta = () => (tree: Root) => {
+  visit(tree, "element", (node: Element) => {
+    if (node.tagName !== "code") return;
+    const meta = node.data?.meta;
+    if (typeof meta !== "string" || meta.length === 0) return;
+
+    node.properties ??= {};
+    node.properties["data-meta"] = meta;
+  });
+};

--- a/velite/rehype-image-size.ts
+++ b/velite/rehype-image-size.ts
@@ -1,0 +1,84 @@
+// MDX本文中のimg要素にwidth/height属性を注入するrehypeプラグイン。
+//
+// なぜrehypeプラグインが必要か:
+// MDXのimg("![alt](./images/xxx.jpeg)")はs.image()と違い、Veliteがwidth/height/blurDataURLの
+// メタデータを生成しない(生成するのはfrontmatterのthumbnailフィールドのみ)。
+// 記事本文中の画像は素のMarkdown image構文のままなので、レンダリング時にnext/imageへ渡す
+// width/heightが無く、CLS(レイアウトシフト)の原因になる。
+//
+// 実行順序の制約(実装時に確定した重要事項):
+// velite の s.mdx() は remarkPlugins に [remarkGfm, remarkRemoveComments, remarkCopyLinkedFiles, ...(config指定分)]
+// を必ずこの順で積む。つまり velite.config.ts の mdx.remarkPlugins で追加するプラグインは
+// 必ず remarkCopyLinkedFiles より「後」に実行される。そのため mdast(remark)段階で画像パスを見ても、
+// 既に `/static/xxxxxxxx-hash.ext` へ書き換わった後の値しか見えない(コピー前のcontent/blogs/.../images/相対パスは失われる)。
+// この制約により、本プラグインはrehype(hast)段階で動作し、書き換え後の `/static/...` パスから
+// public/static配下の実ファイルを直接読んでサイズを取得する方式を採る。
+//
+// velite標準の output 設定(output.assets 既定値 "public/static", output.base 既定値 "/static/")
+// に依存するため、projectRoot(process.cwd())を基点に解決する。
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { visit } from "unist-util-visit";
+import sharp from "sharp";
+import type { Root, Element } from "hast";
+
+// veliteのoutput既定値(velite.config.tsでoutputを明示指定していないため既定値のまま)
+const OUTPUT_BASE = "/static/";
+const OUTPUT_ASSETS_DIR = "public/static";
+
+// 画像サイズのキャッシュ(同一画像が複数記事から参照されるケースの重複読み込みを防ぐ)
+const sizeCache = new Map<string, { width: number; height: number } | null>();
+
+const resolvePublicAssetPath = (src: string): string | null => {
+  if (!src.startsWith(OUTPUT_BASE)) return null;
+  const relative = src.slice(OUTPUT_BASE.length);
+  return path.join(process.cwd(), OUTPUT_ASSETS_DIR, relative);
+};
+
+const readImageSize = async (
+  assetPath: string,
+): Promise<{ width: number; height: number } | null> => {
+  const cached = sizeCache.get(assetPath);
+  if (cached !== undefined) return cached;
+
+  try {
+    const buffer = await readFile(assetPath);
+    const metadata = await sharp(buffer).metadata();
+    if (!metadata.width || !metadata.height) {
+      sizeCache.set(assetPath, null);
+      return null;
+    }
+    const size = { width: metadata.width, height: metadata.height };
+    sizeCache.set(assetPath, size);
+    return size;
+  } catch {
+    // 画像が見つからない・破損している等の場合はwidth/height無しでフォールバックさせる
+    sizeCache.set(assetPath, null);
+    return null;
+  }
+};
+
+export const rehypeImageSize = () => async (tree: Root) => {
+  const imageNodes: Element[] = [];
+  visit(tree, "element", (node: Element) => {
+    if (node.tagName === "img") imageNodes.push(node);
+  });
+
+  await Promise.all(
+    imageNodes.map(async (node) => {
+      const src = node.properties?.src;
+      if (typeof src !== "string") return;
+
+      const assetPath = resolvePublicAssetPath(src);
+      if (!assetPath) return;
+
+      const size = await readImageSize(assetPath);
+      if (!size) return;
+
+      node.properties ??= {};
+      node.properties.width = size.width;
+      node.properties.height = size.height;
+    }),
+  );
+};

--- a/velite/rehype-restore-heading-ids.ts
+++ b/velite/rehype-restore-heading-ids.ts
@@ -1,0 +1,40 @@
+// 見出し(h1〜h6)にmicroCMS由来のidを復元するrehypeプラグイン。
+//
+// 背景(docs/adr/0001-content-layer.md 決定6):
+// MDXでは `{#custom-id}` 記法(acornパースエラー)や `<h2 id="...">` のJSXリテラル直書き
+// (componentsマップが適用されずスタイルが失われる)が使えないため、
+// Markdown見出しはそのまま書き、frontmatterの headingIds(出現順のid配列)を
+// rehypeプラグインで文書順に注入する。
+//
+// frontmatterへのアクセス方式:
+// velite の s.mdx() は compile() に「frontmatterを除いた本文」と「元ファイルパス」しか渡さず、
+// rehypeプラグインが受け取るvfileにもfrontmatterは載らない(実機検証済み)。
+// そのため file.path から元のMDXファイルをfsで読み直し、frontmatterのheadingIdsを取得する。
+import { visit } from "unist-util-visit";
+import type { Root, Element } from "hast";
+import type { VFile } from "vfile";
+
+import { readFrontmatter } from "./read-frontmatter";
+
+const HEADING_TAGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
+
+export const rehypeRestoreHeadingIds = () => (tree: Root, file: VFile) => {
+  const frontmatter = readFrontmatter(file.path);
+  const headingIds = Array.isArray(frontmatter.headingIds)
+    ? (frontmatter.headingIds as string[])
+    : [];
+
+  if (headingIds.length === 0) return;
+
+  let index = 0;
+  visit(tree, "element", (node: Element) => {
+    if (!HEADING_TAGS.has(node.tagName)) return;
+
+    const id = headingIds[index];
+    index += 1;
+    if (!id) return;
+
+    node.properties ??= {};
+    node.properties.id = id;
+  });
+};


### PR DESCRIPTION
## 概要

Closes #236

MDXコンテンツのレンダリング基盤を実装し、記事詳細ページをファイルベースへ全面切替しました。

## 実装

- **MdxContent**: Velite `s.mdx()` のfunction-body文字列を `new Function` 評価(コンパイル結果はキャッシュ)。componentsマップは旧 `ReplaceUiParts.lib.tsx` のマッピングを踏襲(h2/h3/p/strong/u/ul/li/a/img/pre/code/table系/br)
- **rehypeプラグイン(ビルド時)**: 見出しid復元(frontmatter `headingIds` を文書順注入。veliteのvfileにfrontmatterが載らないことを実機確認し、file.pathからのfs読みで実装)/ 画像width/height注入(sharp)/ codeメタ(`title="..."`)受け渡し
- **埋め込み**: Tweet(react-tweet採用 → #228のサードパーティCookie解消)/ LinkCard(ビルド時OGP静的カード、`content/ogp-cache.json` 6URL分コミット済み → #229のiframe TBT解消)/ AmazonLink(現行スタイル踏襲)/ MoshimoAffiliate(**ExecutableScript流用でソフトナビ対応維持** — f0b1eb5リグレッション防止)/ Copyable
- **記事詳細ページ**: params/metadata/JSON-LD/本文/TOC/前後ナビ/関連記事すべてcontent.tsへ

## レビュー(Fable 5)で加えた修正

- **ISR廃止(revalidate=false)**: `new Function` はCloudflare Workersランタイムでは動的コード生成禁止(EvalError)のため、ISR再検証時のWorker内レンダリングを排除。コンテンツはリポジトリ内で確定するためISR自体が不要(更新=再デプロイ)
- MdxBlockquoteのクラスがCustomBlockquoteと一致することを確認(+blockquote内p色の子孫セレクタ再現)

## 検証

- velite build: 見出しid/画像サイズ/codeメタの注入をgrepで確認、toc順序と一致 ✅
- dev実測(curl): msmaflink div×9 / 見出しid `hba7e17d1c0` / TOCアンカー / react-tweet DOM / LinkCard OGP / コードファイル名表示 / EN記事 すべて確認 ✅
- lint 0 / tsc 新規0 / test 悪化なし / build 141ページ / build-storybook 成功(ベースラインで壊れていた `#content` エイリアス解決も修正)✅

## 意図的な差異(記録)

- blockquote内pの色: CSS子孫セレクタで再現(MDXは親判定不可)
- リンク内画像も常時PopupModalラップ(実例1件のみ・リンク先はダミーURL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)