### PR TITLE
feat: 一覧・詳細・検索・前後/関連記事のファイルベース化 (#238)

### DIFF
--- a/src/app/[locale]/blogs/[category]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from 'next-intl/server';
@@ -11,6 +10,7 @@ import SideNav from "@/components/SideNav";
 import ZennArticleList from "@/components/ZennArticleList";
 import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import { getLocalizedCategoryName } from "@/lib/i18n-utils";
+import type { BlogListQuery } from "@/types/content";
 import { BLOG_TYPE_QUERY, CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY } from "@/static/blogs";
 import { CATEGORIES, findCategoryBySlug } from "@/static/categories";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
@@ -124,7 +124,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
     [CATEGORY_QUERY]: categoryEntry.id
   };
 
-  const query: MicroCMSQueries = generateQuery(modifiedSearchParams);
+  const query: BlogListQuery = generateQuery(modifiedSearchParams);
 
   return (
     <>

--- a/src/app/[locale]/blogs/[category]/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/page/[page]/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from 'next-intl/server';
@@ -10,33 +9,21 @@ import SearchStateCard from "@/components/SearchStateCard";
 import SideNav from "@/components/SideNav";
 import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import { getLocalizedCategoryName } from "@/lib/i18n-utils";
-import { getBlogListByLocale } from "@/lib/microcms";
+import { getBlogList } from "@/lib/content";
+import type { BlogListQuery, ContentLocale } from "@/types/content";
 import { PER_PAGE } from "@/static/blogs";
 import { CATEGORIES, findCategoryBySlug } from "@/static/categories";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
 import { locales } from '@/i18n/config';
 
 export async function generateStaticParams() {
-  // ロケール×カテゴリの組み合わせを並列フェッチする（sitemap.tsのcategoryTotalsと同じ方針。
-  // 直列await(for-of内)だとカテゴリ数×ロケール数分のリクエストがビルド時間に積み上がるため）
+  // ロケール×カテゴリの組み合わせごとに件数を集計する
   const combinations = locales.flatMap((locale) => CATEGORIES.map((category) => ({ locale, category })));
 
-  const totalPagesByCombination = await Promise.all(
-    combinations.map(async ({ locale, category }) => {
-      try {
-        const query: MicroCMSQueries = {
-          limit: 1,
-          filters: `category[contains]${category.id}`
-        };
-
-        const data = await getBlogListByLocale(locale, query);
-        return { locale, category, totalPages: Math.ceil(data.totalCount / PER_PAGE) };
-      } catch (error) {
-        console.warn(`カテゴリの静的パラメータ生成に失敗しました: ${category.name}`, error);
-        return { locale, category, totalPages: 0 };
-      }
-    })
-  );
+  const totalPagesByCombination = combinations.map(({ locale, category }) => {
+    const data = getBlogList(locale as ContentLocale, { limit: 1, category: category.id });
+    return { locale, category, totalPages: Math.ceil(data.totalCount / PER_PAGE) };
+  });
 
   return totalPagesByCombination.flatMap(({ locale, category, totalPages }) =>
     // ページ2以降のパラメータを生成（ページ1は /blogs/[category] にある）
@@ -100,12 +87,8 @@ const Page = async ({ params }: PageProps) => {
     notFound();
   }
 
-  // このカテゴリでページが存在するかチェック（microCMSへのフィルタは必ずcontent idを使う）
-  const checkQuery: MicroCMSQueries = {
-    limit: 1,
-    filters: `category[contains]${categoryEntry.id}`
-  };
-  const data = await getBlogListByLocale(locale, checkQuery);
+  // このカテゴリでページが存在するかチェック（フィルタは必ずcontent idを使う）
+  const data = getBlogList(locale as ContentLocale, { limit: 1, category: categoryEntry.id });
   const totalPages = Math.ceil(data.totalCount / PER_PAGE);
 
   if (pageNum > totalPages) {
@@ -113,7 +96,7 @@ const Page = async ({ params }: PageProps) => {
   }
 
   const blogType = "blogs";
-  const query: MicroCMSQueries = generateQuery({
+  const query: BlogListQuery = generateQuery({
     page,
     category: categoryEntry.id,
     keyword: ""

--- a/src/app/[locale]/blogs/page.tsx
+++ b/src/app/[locale]/blogs/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
@@ -10,6 +9,7 @@ import SideNav from "@/components/SideNav";
 import ZennArticleList from "@/components/ZennArticleList";
 import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import { getLocalizedCategoryName } from "@/lib/i18n-utils";
+import type { BlogListQuery } from "@/types/content";
 import {
   BLOG_TYPE_QUERY,
   CATEGORY_QUERY,
@@ -122,7 +122,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
   const blogType = resolvedSearchParams[BLOG_TYPE_QUERY] || "blogs";
   const page = resolvedSearchParams[PAGE_QUERY] || "1";
 
-  const query: MicroCMSQueries = generateQuery(resolvedSearchParams);
+  const query: BlogListQuery = generateQuery(resolvedSearchParams);
   const categoryEntry = category ? resolveCategoryEntry(category) : undefined;
   const categoryLabel = categoryEntry ? getLocalizedCategoryName(categoryEntry, locale) : category;
 

--- a/src/app/[locale]/blogs/page/[page]/page.tsx
+++ b/src/app/[locale]/blogs/page/[page]/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-import type { MicroCMSQueries } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from 'next-intl/server';
@@ -9,16 +8,17 @@ import Skelton from "@/components/ArticleList/skelton";
 import SideNav from "@/components/SideNav";
 import { generateQuery, buildPageUrl, buildLanguageAlternates } from "@/lib";
 import BlogTypeTabs from "@/components/UiParts/BlogTypeTabs";
-import { getBlogListByLocale } from "@/lib/microcms";
+import { getBlogList } from "@/lib/content";
+import type { BlogListQuery, ContentLocale } from "@/types/content";
 import { PER_PAGE } from "@/static/blogs";
 import { locales } from '@/i18n/config';
 
 export async function generateStaticParams() {
   const params = [];
-  
+
   for (const locale of locales) {
     // 各ロケールごとにデータを取得
-    const data = await getBlogListByLocale(locale, { limit: 1 });
+    const data = getBlogList(locale as ContentLocale, { limit: 1 });
     const totalPages = Math.ceil(data.totalCount / PER_PAGE);
     
     // ページ2以降のパラメータを生成（ページ1は/[locale]/blogsにある）
@@ -66,7 +66,7 @@ const Page = async ({ params }: { params: Promise<{ locale: string; page: string
   }
 
   // ページが存在するかチェック
-  const data = await getBlogListByLocale(locale, { limit: 1 });
+  const data = getBlogList(locale as ContentLocale, { limit: 1 });
   const totalPages = Math.ceil(data.totalCount / PER_PAGE);
 
   if (pageNum > totalPages) {
@@ -74,7 +74,7 @@ const Page = async ({ params }: { params: Promise<{ locale: string; page: string
   }
 
   const blogType = "blogs";
-  const query: MicroCMSQueries = generateQuery({
+  const query: BlogListQuery = generateQuery({
     page,
     category: "",
     keyword: ""

--- a/src/components/ArticleList/ArticleCard/index.stories.tsx
+++ b/src/components/ArticleList/ArticleCard/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import ArticleCard from ".";
-import type { BlogsContentType } from "@/types/microcms";
+import type { BlogPost } from "@/types/content";
 
 const meta = {
   title: 'Components/ArticleCard',
@@ -16,46 +16,31 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const data: BlogsContentType = {
-  "id": "customdomain-apprunner-with-terraform-route53",
-  "createdAt": "2024-06-14T05:36:56.274Z",
-  "updatedAt": "2024-06-15T04:26:30.883Z",
-  "publishedAt": new Date().toString(),
-  "revisedAt": "2024-06-15T04:26:30.883Z",
+const data: BlogPost = {
+  "slug": "customdomain-apprunner-with-terraform-route53",
+  "locale": "ja",
+  "publishedAt": new Date().toISOString(),
+  "updatedAt": new Date().toISOString(),
   "title": "タイトルテキストタイトルテキストタイトルテキストタイトルテキストタイトルテキスト",
-  "body": [
-    {
-      "fieldId": "richEditor",
-      "richEditor": ""
-    }
-  ],
   "description": "今回は〇〇する方法を紹介していきます！今回は〇〇する方法を紹介していきます！今回は〇〇する方法を紹介していきます！今回は〇〇する方法を紹介していきます！",
   "noIndex": false,
   "isAdvertisement": false,
   "thumbnail": {
-    "url": "./no_contents.png",
+    "src": "./no_contents.png",
     "height": 1080,
-    "width": 1920
+    "width": 1920,
+    "blurDataURL": "",
+    "blurWidth": 8,
+    "blurHeight": 8
   },
-  "category": [
-    {
-      "id": "aws",
-      "createdAt": "2024-05-25T05:31:41.218Z",
-      "updatedAt": "2024-05-25T07:13:41.932Z",
-      "publishedAt": "2024-05-25T05:31:41.218Z",
-      "revisedAt": "2024-05-25T05:31:41.218Z",
-      "name": "AWS"
-    },
-    {
-      "id": "terraform",
-      "createdAt": "2024-06-14T05:40:43.012Z",
-      "updatedAt": "2024-06-14T06:08:40.759Z",
-      "publishedAt": "2024-06-14T05:40:43.012Z",
-      "revisedAt": "2024-06-14T05:40:43.012Z",
-      "name": "Terraform"
-    }
-  ],
-  "relatedContent": []
+  "categories": ["aws", "terraform"],
+  "related": [],
+  "headingIds": [],
+  "moshimoWidgets": [],
+  "body": "",
+  "raw": "",
+  "toc": [],
+  "plainText": "",
 }
 
 export const Default: Story = {

--- a/src/components/ArticleList/ArticleCard/index.tsx
+++ b/src/components/ArticleList/ArticleCard/index.tsx
@@ -3,18 +3,18 @@
 import { Link } from "next-view-transitions";
 import { useLocale, useTranslations } from "next-intl";
 
-import { BlogsContentType } from "@/types/microcms";
+import type { BlogPost } from "@/types/content";
 import NewLabel from "@/components/UiParts/NewLabel";
 import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton";
 import { isWithinTwoWeeks } from "@/util";
-import { getPrimaryCategoryId } from "@/lib";
+import { getPrimaryCategoryIdFromBlogPost } from "@/lib/content";
 import { getBlogPath } from "@/lib/i18n-utils";
 
 type ArticleCardProps = {
   /**
    * ブログ記事のデータ
    */
-  data: BlogsContentType;
+  data: BlogPost;
   /**
    * インデックス
    */
@@ -24,8 +24,8 @@ type ArticleCardProps = {
 const ArticleCard = ({ data, index }: ArticleCardProps) => {
   const locale = useLocale();
   const t = useTranslations("blog");
-  const categoryId = getPrimaryCategoryId(data);
-  const blogPath = getBlogPath(locale, categoryId, data.id);
+  const categoryId = getPrimaryCategoryIdFromBlogPost(data);
+  const blogPath = getBlogPath(locale, categoryId, data.slug);
 
   // LCP最適化: モバイル（1列）は最初の1枚、デスクトップ（2列）は最初の2枚がLCP候補
   // SSR時に正しい値を出力する必要があるため、両方をカバーするindex <= 1を使用
@@ -72,7 +72,7 @@ const ArticleCard = ({ data, index }: ArticleCardProps) => {
             >
               <figure className="relative w-full transition-opacity hover:opacity-80">
                 <ImageWithSkeleton
-                  src={data.thumbnail.url}
+                  src={data.thumbnail.src}
                   alt={data.title}
                   width={data.thumbnail.width}
                   height={data.thumbnail.height}
@@ -81,7 +81,7 @@ const ArticleCard = ({ data, index }: ArticleCardProps) => {
                     width: "100%",
                     height: "auto",
                     // 記事詳細のアイキャッチ画像と同じ名前を付け、遷移時にサムネイルがそのままモーフするようにする
-                    viewTransitionName: `thumb-${data.id}`,
+                    viewTransitionName: `thumb-${data.slug}`,
                   }}
                   {...lcpImageProps}
                 />

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -2,17 +2,16 @@ import dynamic from "next/dynamic";
 import { Suspense } from "react";
 
 import ArticleCard from "@/components/ArticleList/ArticleCard";
-import { getBlogListByLocale } from "@/lib/microcms";
+import { getBlogList } from "@/lib/content";
 import { PER_PAGE } from "@/static/blogs";
 import type { BlogTypeKeyLIteralType } from "@/types";
-import type { MicroCMSQueries } from "microcms-js-sdk";
+import type { BlogListQuery, BlogPost, ContentLocale } from "@/types/content";
 import NoContents from "@/components/UiParts/NoContentsPage";
-import { BlogsContentType } from "@/types/microcms";
 
 const Pagination = dynamic(() => import("@/components/Pagination"));
 
 type ArticleListProps = {
-  query: MicroCMSQueries
+  query: BlogListQuery
   blogType: BlogTypeKeyLIteralType
   page: string
   basePath?: string
@@ -20,12 +19,9 @@ type ArticleListProps = {
 }
 
 const ArticleList = async ({ query, blogType, page, basePath, locale }: ArticleListProps) => {
-  // NOTE: 一覧で使うフィールドのみ取得し、記事本文(body)がRSCペイロードに混入するのを防ぐ
-  const data = await getBlogListByLocale(
-    locale,
-    { ...query, orders: "-publishedAt", fields: "id,title,description,publishedAt,updatedAt,thumbnail,category" },
-    { next: { revalidate: 86400 } }
-  );
+  // NOTE: content.tsのgetBlogListは常にpublishedAt降順で返すため、
+  // microCMS時代のorders/fields指定(取得フィールド絞り込み)は不要になった
+  const data = getBlogList(locale as ContentLocale, query);
   const contentCount = data.contents.length
   const emptyItem = PER_PAGE - contentCount
   return (
@@ -33,9 +29,9 @@ const ArticleList = async ({ query, blogType, page, basePath, locale }: ArticleL
       {data.totalCount !== 0
         ?
         <ul className="flex-imtem grid grid-cols-1 xl:grid-cols-2 gap-4">
-          {data.contents.map((item: BlogsContentType, index: number) => (
+          {data.contents.map((item: BlogPost, index: number) => (
             <li
-              key={item.id}
+              key={item.slug}
               data-testid={`pw-article-card-${index}`}
               className="animate-fadeIn"
               style={{ animationDelay: `${Math.min(index, 6) * 50}ms` }}

--- a/src/lib/__tests__/content.spec.ts
+++ b/src/lib/__tests__/content.spec.ts
@@ -90,6 +90,30 @@ describe("content.ts", () => {
       expect(result.totalCount).toBe(0);
     });
 
+    it("キーワード検索: 大文字小文字を無視して一致する", () => {
+      const lower = getBlogList("en", { offset: 0, limit: 100, keyword: "next" });
+      const upper = getBlogList("en", { offset: 0, limit: 100, keyword: "NEXT" });
+      const mixed = getBlogList("en", { offset: 0, limit: 100, keyword: "NeXt" });
+      expect(lower.totalCount).toBeGreaterThan(0);
+      expect(upper.totalCount).toBe(lower.totalCount);
+      expect(mixed.totalCount).toBe(lower.totalCount);
+    });
+
+    it("キーワード検索: 全角英数字と半角英数字をNFKC正規化により同一視する", () => {
+      // "Ｎｅｘｔ"(全角) と "Next"(半角) が同じヒット件数になる
+      const halfWidth = getBlogList("en", { offset: 0, limit: 100, keyword: "Next" });
+      const fullWidth = getBlogList("en", { offset: 0, limit: 100, keyword: "Ｎｅｘｔ" });
+      expect(halfWidth.totalCount).toBeGreaterThan(0);
+      expect(fullWidth.totalCount).toBe(halfWidth.totalCount);
+    });
+
+    it("キーワード検索: 全角カタカナと半角カタカナをNFKC正規化により同一視する", () => {
+      const fullWidthKana = getBlogList("ja", { offset: 0, limit: 100, keyword: "ヒトオシ" });
+      const halfWidthKana = getBlogList("ja", { offset: 0, limit: 100, keyword: "ﾋﾄｵｼ" });
+      expect(fullWidthKana.totalCount).toBeGreaterThan(0);
+      expect(halfWidthKana.totalCount).toBe(fullWidthKana.totalCount);
+    });
+
     it("カテゴリとキーワードを同時に指定するとAND条件になる", () => {
       const categoryOnly = getBlogList("ja", { offset: 0, limit: 100, category: "aws" });
       expect(categoryOnly.totalCount).toBe(4);

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -29,14 +29,19 @@ const blogsByLocale = (locale: ContentLocale): BlogPost[] =>
 const getPublishedBlogsByLocale = (locale: ContentLocale): BlogPost[] =>
   blogsByLocale(locale);
 
-// キーワードがtitle/description/plainTextのいずれかに大文字小文字無視で部分一致するか判定する
+// 検索語・対象文字列の表記ゆれを吸収する正規化。
+// NFKC正規化で全角英数字/記号と半角を同一視し(例: "Ｎｅｘｔ" と "Next"を一致させる)、
+// その後toLowerCaseで大文字小文字を無視する。
+const normalizeForSearch = (value: string): string => value.normalize("NFKC").toLowerCase();
+
+// キーワードがtitle/description/plainTextのいずれかに大文字小文字・全半角無視で部分一致するか判定する
 // (microCMSの `q` パラメータ相当。microCMSの`q`は全文検索だが、本データ層ではこの3フィールドに限定する)
 const matchesKeyword = (blog: BlogPost, keyword: string): boolean => {
-  const normalizedKeyword = keyword.toLowerCase();
+  const normalizedKeyword = normalizeForSearch(keyword);
   return (
-    blog.title.toLowerCase().includes(normalizedKeyword) ||
-    blog.description.toLowerCase().includes(normalizedKeyword) ||
-    blog.plainText.toLowerCase().includes(normalizedKeyword)
+    normalizeForSearch(blog.title).includes(normalizedKeyword) ||
+    normalizeForSearch(blog.description).includes(normalizedKeyword) ||
+    normalizeForSearch(blog.plainText).includes(normalizedKeyword)
   );
 };
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,3 @@
-import type { MicroCMSQueries } from "microcms-js-sdk";
 import { getTranslations } from 'next-intl/server';
 
 import type { BreadcrumbItemType, TOCAssetsType } from "@/types";
@@ -6,6 +5,7 @@ import { CATEGORY_QUERY, KEYWORD_QUERY, PAGE_QUERY, PER_PAGE } from "@/static/bl
 import { resolveCategoryEntry, resolveCategoryOrDefault } from "@/static/categories";
 import { getLocalizedCategoryName } from "@/lib/i18n-utils";
 import type { BlogsContentType } from "@/types/microcms";
+import type { BlogListQuery } from "@/types/content";
 import { baseURL } from "@/config";
 import { locales } from "@/i18n/config";
 
@@ -38,9 +38,13 @@ export const generateTOCAssets = (html: string) => {
   return results;
 }
 
-export const generateQuery = (searchParams: { [PAGE_QUERY]: string, [CATEGORY_QUERY]: string, [KEYWORD_QUERY]: string }) => {
-  let filters = "";
-  const query: MicroCMSQueries = { limit: PER_PAGE, offset: 0 }
+// searchParams(?page=&category=&keyword=)を lib/content.ts の getBlogList が受け取る
+// BlogListQuery({offset,limit,category,keyword})に変換する。
+// 旧実装はmicroCMSのクエリ文字列(filters/q)を組み立てていたが、#238でデータ層をVeliteベースの
+// lib/content.tsに切り替えたことに伴い、クエリ文字列ではなく構造化引数を返す形に書き換えた。
+// 呼び出し側(page → generateQuery → ArticleList)の3段構成・関数名は維持している。
+export const generateQuery = (searchParams: { [PAGE_QUERY]: string, [CATEGORY_QUERY]: string, [KEYWORD_QUERY]: string }): BlogListQuery => {
+  const query: BlogListQuery = { limit: PER_PAGE, offset: 0 };
 
   if (searchParams[PAGE_QUERY]) {
     // NOTE: 不正な page 値（非数値・負値）で offset が NaN / 負値になるのを防ぐ
@@ -48,20 +52,18 @@ export const generateQuery = (searchParams: { [PAGE_QUERY]: string, [CATEGORY_QU
     query.offset = Number.isNaN(pageNum) || pageNum < 1 ? 0 : (pageNum - 1) * PER_PAGE;
   }
 
-  // filters
   if (searchParams[CATEGORY_QUERY]) {
     const categoryValue = searchParams[CATEGORY_QUERY];
-    // カテゴリの表示名(ja/en)・URLスラッグ・content idのいずれで渡されてもmicroCMSのcontent idに解決する
+    // カテゴリの表示名(ja/en)・URLスラッグ・content idのいずれで渡されてもcontent.ts側のカテゴリslugに解決する
     const categoryEntry = resolveCategoryEntry(categoryValue);
-    const categoryId = categoryEntry?.id ?? categoryValue;
-    filters += `${CATEGORY_QUERY}[contains]${categoryId}`;
+    query.category = categoryEntry?.id ?? categoryValue;
   }
 
   if (searchParams[KEYWORD_QUERY]) {
-    query.q = searchParams[KEYWORD_QUERY];
+    query.keyword = searchParams[KEYWORD_QUERY];
   }
 
-  return { ...query, filters };
+  return query;
 }
 
 // 記事のプライマリカテゴリのURLスラッグを返す。該当カテゴリがCATEGORIES(src/static/categories.ts)に


### PR DESCRIPTION
## 概要

Closes #238

一覧系ページ(トップ/ページネーション/カテゴリ別)と検索をファイルベースデータへ切り替えました(詳細・前後・関連は#236で切替済み)。

## 変更点

- `generateQuery`: microCMSクエリ文字列組み立て → `BlogListQuery` 構造化引数への変換関数に書き換え(page → generateQuery → ArticleList の3段構成・関数名は維持)
- `ArticleList`/`ArticleCard`: content.tsベースへ。サムネイルは `thumbnail.src`(/static/)、viewTransitionNameを詳細側と統一
- 検索: NFKC正規化+小文字化(「Next/Ｎｅｘｔ」「ヒトオシ/ﾋﾄｵｼ」を同一視、ユニットテスト3件追加)
- パリティ維持: PER_PAGE=4 / 0件時no_contents / 範囲外notFound() / publishedAt降順

## 検証

- dev実測(curl): /ja/blogs 4件降順 / page/2 / カテゴリ絞込 / keyword検索(ja/en) / 0件表示 / page/999→404 / 一覧HTMLにmicrocms-assets参照ゼロ ✅
- lint 0 / tsc 新規0 / test 44パス(新規3含む・悪化なし) / build 成功 ✅
- e2e search.spec.ts: 検索動作自体は正常。3件失敗は**テスト側の設計問題**(SPA遷移でloadイベント不発火のためwaitForURLがタイムアウト)+playwright.config.tsのwebServerがstandalone非互換 → **#241で修正**(詳細をIssueコメントに記録)

## 残存microCMS参照(意図的)

- `admin/ai-access`ページのみ(D1ログとの突合用途、#243で扱い検討)

🤖 Generated with [Claude Code](https://claude.com/claude-code)