### PR TITLE
fix: 存在しない記事slugで500ではなく404を返す

### DIFF
--- a/e2e/article.spec.ts
+++ b/e2e/article.spec.ts
@@ -139,4 +139,14 @@ test.describe('記事詳細ページのテスト', () => {
       }
     }
   });
+
+  test('ART-07: 存在しない記事slugは404を返す（500にならない）', async ({ page }) => {
+    // generateMetadataが未捕捉例外で落ちると404ではなく500になるリグレッションの検知用(本番検証で発見)
+    const pageRes = await page.request.get('/ja/blogs/zakki/no-such-article-xyz');
+    expect(pageRes.status()).toBe(404);
+
+    // OGP/Twitter画像ルートも同様に404を返すこと
+    const ogRes = await page.request.get('/ja/blogs/zakki/no-such-article-xyz/opengraph-image');
+    expect(ogRes.status()).toBe(404);
+  });
 });

--- a/src/app/[locale]/blogs/[category]/[blogId]/opengraph-image.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/opengraph-image.tsx
@@ -27,8 +27,14 @@ export default async function Image({
   // localeに基づいて作者名を選択
   const authorName = locale === 'en' ? AUTHOR_NAME_EN : AUTHOR_NAME;
 
-  // タイトルのみ使用するため、ファイルベースのコンテンツ層から取得する
-  const data = getBlogBySlugByLocale(locale as ContentLocale, blogId);
+  // タイトルのみ使用するため、ファイルベースのコンテンツ層から取得する。
+  // 存在しないslugでは例外になるため、500ではなく404を返す(本番検証で発見)
+  let data;
+  try {
+    data = getBlogBySlugByLocale(locale as ContentLocale, blogId);
+  } catch {
+    return new Response("Not Found", { status: 404 });
+  }
 
   return new ImageResponse(
     (

--- a/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/page.tsx
@@ -47,8 +47,15 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   // Next.js 16では、paramsを非同期で取得する必要がある
   const { blogId, locale, category } = await params;
-  // NOTE: ページ本体と同じ cached フェッチを使い、同一リクエスト内の二重フェッチを避ける
-  const data = getBlogBySlugByLocaleCached(locale as ContentLocale, blogId);
+  // NOTE: ページ本体と同じ cached フェッチを使い、同一リクエスト内の二重フェッチを避ける。
+  // 存在しないslugでは例外が投げられるが、generateMetadataはページ本体より先に評価されるため、
+  // ここで捕捉してnotFound()しないと404ではなく500になってしまう(本番検証で発見)
+  let data;
+  try {
+    data = getBlogBySlugByLocaleCached(locale as ContentLocale, blogId);
+  } catch {
+    notFound();
+  }
 
   // 記事自身の絶対URL（og:url / canonical に使用）
   const blogUrl = buildPageUrl(locale, "blogs", category, blogId);

--- a/src/app/[locale]/blogs/[category]/[blogId]/twitter-image.tsx
+++ b/src/app/[locale]/blogs/[category]/[blogId]/twitter-image.tsx
@@ -20,8 +20,14 @@ export default async function Image({
   // Next.js 16ではparamsがPromiseになるため、awaitで解決
   const { locale, blogId } = await params;
 
-  // タイトルのみ使用するため、ファイルベースのコンテンツ層から取得する
-  const data = getBlogBySlugByLocale(locale as ContentLocale, blogId);
+  // タイトルのみ使用するため、ファイルベースのコンテンツ層から取得する。
+  // 存在しないslugでは例外になるため、500ではなく404を返す(本番検証で発見)
+  let data;
+  try {
+    data = getBlogBySlugByLocale(locale as ContentLocale, blogId);
+  } catch {
+    return new Response("Not Found", { status: 404 });
+  }
   return new ImageResponse(
     (
       <div


### PR DESCRIPTION
本番最終確認で発見した500バグの修正(#260)。generateMetadata/OGP画像ルートの未捕捉例外→404化+e2e回帰テスト。

🤖 Generated with [Claude Code](https://claude.com/claude-code)