### PR TITLE
fix: StorybookデプロイのVelite依存解決

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -26,6 +26,12 @@ jobs:
 
       - run: npm ci
 
+      # src/lib/content.ts が import する .velite/ はビルド時生成物のため、
+      # Storybookビルド前にVeliteでコンテンツデータを生成する必要がある
+      # (package.jsonのprebuild-storybookフックでも実行されるが、CIでは明示しておく)
+      - name: Generate content data (Velite)
+        run: NODE_ENV=development npx velite build
+
       - name: Build Storybook
         run: npm run build-storybook
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "e2e:dev": "./run-e2e-tests.sh",
     "e2e:serve": "cp -r public .next/standalone/ && cp -r .next/static .next/standalone/.next/ && PORT=3001 node .next/standalone/server.js",
     "storybook": "storybook dev -p 6006",
+    "prebuild-storybook": "NODE_ENV=development velite build",
     "build-storybook": "storybook build",
     "update-rss": "node ./src/static/rss/rss-parser.js",
     "preview:stg": "opennextjs-cloudflare build --config wrangler.stg.jsonc && opennextjs-cloudflare preview --config wrangler.stg.jsonc",


### PR DESCRIPTION
## 概要

本番反映後の動作確認で発見: **Storybookデプロイワークフローが移行リリース(#256/#259)以降失敗**していた。

## 原因

`src/lib/content.ts` がimportする `.velite/`(ビルド時生成物)を、Storybookワークフローが生成していなかった(`Could not load ./.velite/index`)。

## 修正

- package.json: `prebuild-storybook` フックで `velite build`(ローカルのフレッシュ環境も救済)
- deploy-storybook.yml: 明示的なVelite生成ステップ追加(path filterに合致するためマージで動作検証される)

## 検証

`.velite`削除状態から `npm run build-storybook` 成功(CI相当の再現)✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)