### PR TITLE
fix: 新規記事の見出しid自動生成(目次の空表示を修正)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "eslint-config-next": "^16.2.3",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-storybook": "^0.8.0",
+        "github-slugger": "^2.0.0",
         "hast-util-to-mdast": "^10.1.2",
         "js-yaml": "^4.3.0",
         "jsdom": "^24.0.0",
@@ -14946,6 +14947,13 @@
       "version": "0.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "10.3.10",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-config-next": "^16.2.3",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-storybook": "^0.8.0",
+    "github-slugger": "^2.0.0",
     "hast-util-to-mdast": "^10.1.2",
     "js-yaml": "^4.3.0",
     "jsdom": "^24.0.0",

--- a/src/lib/__tests__/content.spec.ts
+++ b/src/lib/__tests__/content.spec.ts
@@ -1,3 +1,7 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -8,13 +12,38 @@ import {
 } from "../content";
 import { PER_PAGE } from "@/static/blogs";
 
-// 実データ(.velite出力の日英各30記事、計60記事)を使って検証する。
+// 実データ(.velite出力)を使って検証する。
 // vitest実行前に `pretest` フック(package.json)で `velite build` が走り、.velite/ が生成される前提。
+//
+// 期待値は記事数のハードコードではなく、content/blogs/ のファイルシステムを
+// 「独立したオラクル」として算出する(記事を追加するたびにテストが壊れるのを防ぐ。
+// 2026-07-07、31本目の記事追加で件数固定の旧テストが赤くなったことへの対処)。
+// NOTE: pretest は NODE_ENV=development で velite build するため、draft記事も
+// .velite に含まれる。ファイル数ベースのオラクルはこれと常に一致する。
+const BLOGS_DIR = path.join(__dirname, "..", "..", "..", "content", "blogs");
+
+type BlogFrontmatter = { categories?: string[] };
+
+const listFrontmattersByLocale = (locale: "ja" | "en"): BlogFrontmatter[] =>
+  readdirSync(BLOGS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => {
+      const file = path.join(BLOGS_DIR, entry.name, `index.${locale}.mdx`);
+      if (!existsSync(file)) return [];
+      const match = readFileSync(file, "utf-8").match(/^---\r?\n([\s\S]*?)\r?\n---/);
+      return match ? [yaml.load(match[1]) as BlogFrontmatter] : [];
+    });
+
+const jaFrontmatters = listFrontmattersByLocale("ja");
+const jaTotal = jaFrontmatters.length;
+const countJaByCategory = (category: string) =>
+  jaFrontmatters.filter((fm) => fm.categories?.includes(category)).length;
+
 describe("content.ts", () => {
   describe("getAllBlogListByLocale", () => {
-    it("ja/enそれぞれ30件ずつ返す", () => {
-      expect(getAllBlogListByLocale("ja")).toHaveLength(30);
-      expect(getAllBlogListByLocale("en")).toHaveLength(30);
+    it("content/blogs/のファイル数と同じ件数をja/enそれぞれ返す", () => {
+      expect(getAllBlogListByLocale("ja")).toHaveLength(jaTotal);
+      expect(getAllBlogListByLocale("en")).toHaveLength(listFrontmattersByLocale("en").length);
     });
 
     it("publishedAt降順(新しい順)にソートされている", () => {
@@ -26,9 +55,10 @@ describe("content.ts", () => {
       }
     });
 
-    it("最新記事が先頭に来る", () => {
+    it("最新記事(publishedAt最大)が先頭に来る", () => {
       const list = getAllBlogListByLocale("ja");
-      expect(list[0].slug).toBe("best-buy-2026-first-half");
+      const newest = Math.max(...list.map((blog) => new Date(blog.publishedAt).getTime()));
+      expect(new Date(list[0].publishedAt).getTime()).toBe(newest);
     });
   });
 
@@ -39,7 +69,7 @@ describe("content.ts", () => {
 
       expect(page1.contents).toHaveLength(PER_PAGE);
       expect(page2.contents).toHaveLength(PER_PAGE);
-      expect(page1.totalCount).toBe(30);
+      expect(page1.totalCount).toBe(jaTotal);
       expect(page1.offset).toBe(0);
       expect(page1.limit).toBe(PER_PAGE);
 
@@ -50,21 +80,24 @@ describe("content.ts", () => {
     });
 
     it("最終ページは端数件数のみ返す", () => {
-      // 30件をPER_PAGE=4で割ると7ページ+2件
-      const lastPage = getBlogList("ja", { offset: 28, limit: PER_PAGE });
-      expect(lastPage.contents).toHaveLength(2);
-      expect(lastPage.totalCount).toBe(30);
+      // 最終ページのoffsetと端数件数を全記事数から算出する(端数0の場合はPER_PAGE件になる)
+      const lastPageOffset = Math.floor((jaTotal - 1) / PER_PAGE) * PER_PAGE;
+      const expectedCount = jaTotal - lastPageOffset;
+      const lastPage = getBlogList("ja", { offset: lastPageOffset, limit: PER_PAGE });
+      expect(lastPage.contents).toHaveLength(expectedCount);
+      expect(lastPage.totalCount).toBe(jaTotal);
     });
 
     it("範囲外のoffsetは空配列を返すがtotalCountは全体件数を維持する", () => {
-      const result = getBlogList("ja", { offset: 1000, limit: PER_PAGE });
+      const result = getBlogList("ja", { offset: jaTotal + 1000, limit: PER_PAGE });
       expect(result.contents).toHaveLength(0);
-      expect(result.totalCount).toBe(30);
+      expect(result.totalCount).toBe(jaTotal);
     });
 
     it("カテゴリで絞り込める(categories配列のいずれかに一致)", () => {
       const result = getBlogList("ja", { offset: 0, limit: 100, category: "zakki" });
-      expect(result.totalCount).toBe(11);
+      expect(result.totalCount).toBe(countJaByCategory("zakki"));
+      expect(result.totalCount).toBeGreaterThan(0);
       result.contents.forEach((content) => {
         expect(content.categories).toContain("zakki");
       });
@@ -116,7 +149,8 @@ describe("content.ts", () => {
 
     it("カテゴリとキーワードを同時に指定するとAND条件になる", () => {
       const categoryOnly = getBlogList("ja", { offset: 0, limit: 100, category: "aws" });
-      expect(categoryOnly.totalCount).toBe(4);
+      expect(categoryOnly.totalCount).toBe(countJaByCategory("aws"));
+      expect(categoryOnly.totalCount).toBeGreaterThan(0);
 
       const combined = getBlogList("ja", {
         offset: 0,

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -81,7 +81,9 @@ const blogs = defineCollection({
       isAdvertisement: s.boolean().default(false),
       // 関連記事slug配列
       related: s.array(s.string()).default([]),
-      // microCMS由来の見出しid(出現順)。rehype-slug相当の後方互換用
+      // microCMS由来の見出しid(出現順)。移行記事の後方互換用。
+      // 空(=新規記事)の場合はTOC・HTMLとも見出しテキストからidを自動生成する
+      // (velite/mdast-utils.ts の computeHeadingSlugs を参照)
       headingIds: s.array(s.string()).default([]),
       // 下書きフラグ。true の記事は本番ビルドの出力から除外される(prepareフック参照)。
       // 開発環境(NODE_ENV=development、package.jsonのpredev/dev/pretest参照)では除外しない

--- a/velite/mdast-utils.test.ts
+++ b/velite/mdast-utils.test.ts
@@ -1,0 +1,49 @@
+// computeHeadingSlugs / extractToc のユニットテスト。
+// 「新規記事(headingIds無し)のTOC idが全てnullになり目次が空表示になる」バグ(2026-07-07修正)の回帰防止。
+import { describe, expect, it } from "vitest";
+
+import { computeHeadingSlugs, extractToc } from "./mdast-utils";
+
+describe("computeHeadingSlugs", () => {
+  it("日本語見出しから文書順にスラッグを生成する", () => {
+    const raw = "## 何をしたのか\n\n本文\n\n## なぜ脱CMSしたのか\n\n### 補足\n";
+    expect(computeHeadingSlugs(raw)).toEqual(["何をしたのか", "なぜ脱cmsしたのか", "補足"]);
+  });
+
+  it("同名見出しの重複は -1, -2 で回避する", () => {
+    const raw = "## まとめ\n\n## まとめ\n\n## まとめ\n";
+    expect(computeHeadingSlugs(raw)).toEqual(["まとめ", "まとめ-1", "まとめ-2"]);
+  });
+
+  it("コードブロック内の ## は見出しとして数えない", () => {
+    const raw = "## 実装\n\n```bash\n## これはコメント\n```\n";
+    expect(computeHeadingSlugs(raw)).toEqual(["実装"]);
+  });
+
+  it("インラインコード混じりの見出しも文書順のテキストでスラッグ化する", () => {
+    const raw = "## `min-w-0` の明示で根治\n";
+    expect(computeHeadingSlugs(raw)).toEqual(["min-w-0-の明示で根治"]);
+  });
+});
+
+describe("extractToc", () => {
+  const raw = "## 何をしたのか\n\n## 最後に\n";
+
+  it("headingIdsが空の新規記事では自動生成idを割り当てる(nullにしない)", () => {
+    const toc = extractToc(raw, []);
+    expect(toc).toEqual([
+      { depth: 2, text: "何をしたのか", id: "何をしたのか" },
+      { depth: 2, text: "最後に", id: "最後に" },
+    ]);
+  });
+
+  it("headingIdsがある移行記事ではそれをそのまま使う(従来挙動を維持)", () => {
+    const toc = extractToc(raw, ["hba7e17d1c0", "h9036816da0"]);
+    expect(toc.map((entry) => entry.id)).toEqual(["hba7e17d1c0", "h9036816da0"]);
+  });
+
+  it("headingIdsが見出し数より短い移行記事では末尾がnullになる(従来挙動を維持)", () => {
+    const toc = extractToc(raw, ["hba7e17d1c0"]);
+    expect(toc.map((entry) => entry.id)).toEqual(["hba7e17d1c0", null]);
+  });
+});

--- a/velite/mdast-utils.ts
+++ b/velite/mdast-utils.ts
@@ -4,6 +4,7 @@
 // なぜmdastでパースするか:
 // - コードブロック内の `## foo` のような文字列を見出しと誤検出しないため
 // - JSX要素(<MoshimoAffiliate .../> 等)の属性値をテキストとして拾わないため
+import GithubSlugger from "github-slugger";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { mdxFromMarkdown } from "mdast-util-mdx";
 import { gfmFromMarkdown } from "mdast-util-gfm";
@@ -39,10 +40,41 @@ const extractHeadingText = (node: Heading): string => {
   return text.trim();
 };
 
+// スラッグ生成用に、見出しノードのtext/inlineCodeを「文書順」で連結する。
+// (extractHeadingTextはtext全走査→inlineCode全走査の順で連結するため、
+//  コード混じり見出しでは順序が入れ替わりうる。表示用の挙動は変えず、id生成にはこちらを使う)
+const extractHeadingTextInOrder = (node: Heading): string => {
+  let text = "";
+  visit(node, (child) => {
+    if (child.type === "text" || child.type === "inlineCode") {
+      text += (child as { value: string }).value;
+    }
+  });
+  return text.trim();
+};
+
+// 見出しテキストから文書順のid配列を生成する(rehype-slug相当。重複は -1, -2 ... で回避)。
+// frontmatterにheadingIdsを持たない新規記事(2026-07-06移行後に作成)のid付与に使う。
+// TOC(extractToc)とレンダリングHTML(velite/rehype-restore-heading-ids.ts)の両方が
+// この同一関数・同一ソース(生MDX本文)からidを導出することで、アンカーのズレを構造的に防ぐ。
+export const computeHeadingSlugs = (raw: string): string[] => {
+  const tree = parseMdxToMdast(raw);
+  const slugger = new GithubSlugger();
+  const slugs: string[] = [];
+
+  visit(tree, "heading", (node: Heading) => {
+    slugs.push(slugger.slug(extractHeadingTextInOrder(node)));
+  });
+
+  return slugs;
+};
+
 // 文書順のTOCを抽出し、frontmatterのheadingIds(出現順のid配列)と順序ベースでzipする。
+// headingIdsが空(=新規記事)の場合は見出しテキストから自動生成したスラッグを使う。
 // headingIdsが見出し数より短い場合、対応するエントリのidはnullになる。
 export const extractToc = (raw: string, headingIds: string[]): TocEntry[] => {
   const tree = parseMdxToMdast(raw);
+  const ids = headingIds.length > 0 ? headingIds : computeHeadingSlugs(raw);
   const toc: TocEntry[] = [];
   let index = 0;
 
@@ -50,7 +82,7 @@ export const extractToc = (raw: string, headingIds: string[]): TocEntry[] => {
     toc.push({
       depth: node.depth,
       text: extractHeadingText(node),
-      id: headingIds[index] ?? null,
+      id: ids[index] ?? null,
     });
     index++;
   });

--- a/velite/read-frontmatter.ts
+++ b/velite/read-frontmatter.ts
@@ -18,6 +18,22 @@ const frontmatterCache = new Map<string, Record<string, unknown>>();
 // `---\n...\n---` のYAMLフロントマターブロックを抽出する正規表現
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
+// frontmatterを除いた本文のキャッシュ(readMdxBody用)
+const bodyCache = new Map<string, string>();
+
+// 指定したMDXファイルパスから「frontmatterを除いた本文」を返す。
+// veliteが s.raw() でtransformに渡す本文と同じ見出し列になるため、
+// computeHeadingSlugs(velite/mdast-utils.ts)の入力として両者を同一視できる。
+export const readMdxBody = (filePath: string): string => {
+  const cached = bodyCache.get(filePath);
+  if (cached !== undefined) return cached;
+
+  const raw = readFileSync(filePath, "utf-8");
+  const body = raw.replace(FRONTMATTER_PATTERN, "");
+  bodyCache.set(filePath, body);
+  return body;
+};
+
 // 指定したMDXファイルパスからfrontmatterをパースして返す。frontmatterが無い場合は空オブジェクト。
 export const readFrontmatter = (filePath: string): Record<string, unknown> => {
   const cached = frontmatterCache.get(filePath);

--- a/velite/rehype-restore-heading-ids.ts
+++ b/velite/rehype-restore-heading-ids.ts
@@ -1,28 +1,36 @@
-// 見出し(h1〜h6)にmicroCMS由来のidを復元するrehypeプラグイン。
+// 見出し(h1〜h6)にidを注入するrehypeプラグイン。
 //
 // 背景(docs/adr/0001-content-layer.md 決定6):
 // MDXでは `{#custom-id}` 記法(acornパースエラー)や `<h2 id="...">` のJSXリテラル直書き
 // (componentsマップが適用されずスタイルが失われる)が使えないため、
-// Markdown見出しはそのまま書き、frontmatterの headingIds(出現順のid配列)を
-// rehypeプラグインで文書順に注入する。
+// Markdown見出しはそのまま書き、idはrehypeプラグインで文書順に注入する。
+//
+// idのソースは2系統:
+// - 移行記事: frontmatterの headingIds(microCMS由来のid、出現順の配列)を復元する
+// - 新規記事(headingIds無し): 見出しテキストから自動生成する(rehype-slug相当)。
+//   TOC(velite.config.tsのextractToc)と同じ computeHeadingSlugs を同じ本文に対して
+//   使うことで、TOCのアンカーと実HTMLのidが必ず一致する
 //
 // frontmatterへのアクセス方式:
 // velite の s.mdx() は compile() に「frontmatterを除いた本文」と「元ファイルパス」しか渡さず、
 // rehypeプラグインが受け取るvfileにもfrontmatterは載らない(実機検証済み)。
-// そのため file.path から元のMDXファイルをfsで読み直し、frontmatterのheadingIdsを取得する。
+// そのため file.path から元のMDXファイルをfsで読み直し、frontmatter/本文を取得する。
 import { visit } from "unist-util-visit";
 import type { Root, Element } from "hast";
 import type { VFile } from "vfile";
 
-import { readFrontmatter } from "./read-frontmatter";
+import { computeHeadingSlugs } from "./mdast-utils";
+import { readFrontmatter, readMdxBody } from "./read-frontmatter";
 
 const HEADING_TAGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 
 export const rehypeRestoreHeadingIds = () => (tree: Root, file: VFile) => {
   const frontmatter = readFrontmatter(file.path);
-  const headingIds = Array.isArray(frontmatter.headingIds)
+  const restoredIds = Array.isArray(frontmatter.headingIds)
     ? (frontmatter.headingIds as string[])
     : [];
+  const headingIds =
+    restoredIds.length > 0 ? restoredIds : computeHeadingSlugs(readMdxBody(file.path));
 
   if (headingIds.length === 0) return;
 


### PR DESCRIPTION
## 概要

新規記事 `microcms-to-mdx-migration` の記事ページで目次(TOC)が空表示になる不具合の修正です。

## 原因

- 移行記事は frontmatter の `headingIds` から見出しidを復元するが、**新規記事(headingIds無し)のid自動生成が未実装**だった(docs/writing.md §3 の「自動生成される」と実装が乖離)
- `extractToc` が全エントリに `id: null` を返し、`buildTocAssets` が null idを全件スキップ → 目次が空
- `rehypeRestoreHeadingIds` も headingIds が空だと何もしないため、HTML側の見出しにもidが無かった

## 修正

- `computeHeadingSlugs`(github-slugger、見出しテキストから文書順にid生成)を追加
- TOC側(`extractToc`)とHTML側(`rehype-restore-heading-ids`)の両方が**同一関数・同一ソースからidを導出**する構成にし、アンカーのズレを構造的に防止
- `headingIds` を持つ移行記事の挙動は不変(ビルド出力のdiffで無回帰を確認済み)

## あわせて修正

- `content.spec.ts` が記事総数(30件)や最新記事slugをハードコードしており、31本目の記事公開でvitestが5件赤くなっていたため、FSオラクル算出方式に変更(記事追加で壊れないように)

## 検証

- [x] vitest 63/63 パス(回帰保護テスト7件を新規追加)
- [x] `npx tsc --noEmit` / eslint エラーなし
- [x] dev サーバー実機確認: 新記事のTOCアンカーと `<h2 id>` が9/9一致、移行記事はmicroCMS由来idのまま
- [x] `npx velite build` 出力で新記事のtoc idが全て非null、移行記事のtocは変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)