### PR TITLE
fix: ページ遷移時の画像・画面のちらつきを修正

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -17,7 +17,7 @@ const Page = async ({ params }: AboutPageProps) => {
   const { locale } = await params;
 
   return (
-    <article className="mx-auto w-full max-w-4xl animate-fadeIn flex-grow space-y-16 bg-white px-4 py-12 sm:px-6 md:space-y-24 md:py-16 lg:px-8 dark:bg-black">
+    <article className="mx-auto w-full max-w-4xl flex-grow space-y-16 bg-white px-4 py-12 sm:px-6 md:space-y-24 md:py-16 lg:px-8 dark:bg-black">
       <HeroSection locale={locale} />
       <AboutMeSection locale={locale} />
       <MissionSection locale={locale} />

--- a/src/components/ArticleBody/index.tsx
+++ b/src/components/ArticleBody/index.tsx
@@ -10,7 +10,7 @@ import TOCList from "@/components/ArticleBody/TOCList";
 import AdRevenueLabel from "@/components/AdRevenueLabel";
 import PrevAndNextBlogNav from "@/components/ArticleBody/PrevAndNextBlogNav";
 import IssueButton from "@/components/UiParts/IssueButton";
-import { calcDiffYears } from "@/util";
+import { calcDiffYears, thumbnailPlaceholderProps } from "@/util";
 import InfoYearsCard from "@/components/UiParts/InfoYearsCard";
 import CategoryTag from "./CategoryTag";
 import LocaleAwareShare from "./LocaleAwareShare";
@@ -39,6 +39,9 @@ const ArticleBody = ({ data, locale }: ArticleBodyProps) => {
                 alt={data.title}
                 width={data.thumbnail.width}
                 height={data.thumbnail.height}
+                // 一覧カードと同じblurプレースホルダーを使うことで、共有要素モーフ中に
+                // グレーのスケルトンへ一瞬切り替わるちらつきを避ける
+                {...thumbnailPlaceholderProps(data.thumbnail.blurDataURL)}
                 sizes="100vw"
                 style={{
                   height: "auto",

--- a/src/components/ArticleList/ArticleCard/index.tsx
+++ b/src/components/ArticleList/ArticleCard/index.tsx
@@ -6,7 +6,7 @@ import { useLocale, useTranslations } from "next-intl";
 import type { BlogPost } from "@/types/content";
 import NewLabel from "@/components/UiParts/NewLabel";
 import ImageWithSkeleton from "@/components/UiParts/ImageWithSkeleton";
-import { isWithinTwoWeeks } from "@/util";
+import { isWithinTwoWeeks, thumbnailPlaceholderProps } from "@/util";
 import { getPrimaryCategoryIdFromBlogPost } from "@/lib/content";
 import { getBlogPath } from "@/lib/i18n-utils";
 
@@ -76,6 +76,7 @@ const ArticleCard = ({ data, index }: ArticleCardProps) => {
                   alt={data.title}
                   width={data.thumbnail.width}
                   height={data.thumbnail.height}
+                  {...thumbnailPlaceholderProps(data.thumbnail.blurDataURL)}
                   sizes="(max-width: 640px) 100vw, (max-width: 768px) 100vw, (max-width: 1024px) 45vw, (max-width: 1280px) 28vw, 496px"
                   style={{
                     width: "100%",

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -28,13 +28,13 @@ const ArticleList = async ({ query, blogType, page, basePath, locale }: ArticleL
     <div className="flex flex-col justify-between h-full">
       {data.totalCount !== 0
         ?
-        <ul className="flex-imtem grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <ul className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+          {/* NOTE: フェードイン演出(animate-fadeIn)はView Transitionのスナップショットが
+              opacity:0のコンテンツで撮られ、遷移のたびに画面がちらつく原因になるため付けない */}
           {data.contents.map((item: BlogPost, index: number) => (
             <li
               key={item.slug}
               data-testid={`pw-article-card-${index}`}
-              className="animate-fadeIn"
-              style={{ animationDelay: `${Math.min(index, 6) * 50}ms` }}
             >
               <ArticleCard data={item} index={index} />
             </li>

--- a/src/components/UiParts/ImageWithBlur/index.tsx
+++ b/src/components/UiParts/ImageWithBlur/index.tsx
@@ -19,8 +19,11 @@ type ImageWithBlurProps = {
   skeletonClassName?: string
 } & Omit<ImageProps, 'placeholder' | 'blurDataURL' | "src">
 
-// Cloudflare Workersランタイムではfs/sharpが使用不可のため、blurプレースホルダーを省略
-// 読み込み完了までは ImageWithSkeleton によるスケルトン表示に委譲する
+// Cloudflare Workersランタイムではfs/sharpが使用不可のため、ランタイム生成のblurプレースホルダーは使えない。
+// 読み込み完了までは ImageWithSkeleton によるスケルトン表示に委譲する。
+// NOTE: 名前に反して現状blurは表示しない。Velite管理の画像(記事サムネイル等)には
+// ビルド時生成のblurDataURLが存在するため、このコンポーネントではなく
+// ImageWithSkeleton + thumbnailPlaceholderProps(@/util) を直接使うこと(ArticleCard/ArticleBody参照)
 const ImageWithBlur = ({ className = "", src, alt, wrapperClassName = "", skeletonClassName, ...restProps }: ImageWithBlurProps) => {
   return (
     <ImageWithSkeleton

--- a/src/components/UiParts/ImageWithSkeleton/index.spec.tsx
+++ b/src/components/UiParts/ImageWithSkeleton/index.spec.tsx
@@ -127,6 +127,43 @@ describe('ImageWithSkeleton', () => {
     expect(skeleton).toHaveClass('rounded-full');
   });
 
+  it('placeholder="blur" の場合はスケルトンを描画しない（blur画像自体がプレースホルダーとして機能）', () => {
+    // NOTE: ArticleCard / ArticleBody が実際に使う本番経路。
+    // blurの上にスケルトンを重ねると明滅してちらつくため、スケルトンspan自体を出さない
+    const { container } = render(
+      <div className="relative">
+        <ImageWithSkeleton
+          src="/author.png"
+          alt="テスト画像"
+          width={100}
+          height={100}
+          placeholder="blur"
+          blurDataURL="data:image/webp;base64,UklGRiIAAABXRUJQVlA4TBUAAAAvY8AYAAfQ/4j+B/Cg2f8zLNL/VAA="
+        />
+      </div>
+    );
+
+    // スケルトンspanが無いので、直下の子は img のみ
+    expect(container.firstChild?.childNodes).toHaveLength(1);
+    expect((container.firstChild?.firstChild as HTMLElement).tagName).toBe('IMG');
+  });
+
+  it('placeholder="empty" を明示的に渡した場合は従来どおりスケルトンが表示される（ImageWithBlur経由の経路）', () => {
+    render(
+      <ImageWithSkeleton
+        src="/author.png"
+        alt="テスト画像"
+        width={100}
+        height={100}
+        placeholder="empty"
+      />
+    );
+
+    const skeleton = screen.getByRole('img', { hidden: true }).nextSibling as HTMLElement;
+    expect(skeleton).toHaveClass('opacity-100');
+    expect(skeleton).toHaveClass('animate-pulse');
+  });
+
   it('src が変化すると isLoaded がリセットされ、スケルトンが再表示される', async () => {
     const { rerender } = render(
       <ImageWithSkeleton src="/author.png" alt="テスト画像" width={100} height={100} />

--- a/src/components/UiParts/ImageWithSkeleton/index.tsx
+++ b/src/components/UiParts/ImageWithSkeleton/index.tsx
@@ -23,19 +23,22 @@ type ImageWithSkeletonProps = {
  * スケルトンは画像の手前に重ねて表示しフェードアウトさせる方式（画像自体のopacityは操作しない）。
  * これにより priority/preload 指定のLCP対象画像にもスケルトンを適用してよく、LCP計測への悪影響がない。
  *
- * 遷移中に画像要素自体がアンマウント→リマウントされるケース（View Transition時の二重フェッチなど）でも、
- * このコンポーネントごと再マウントされ isLoaded は false から始まり直すため、
- * 最終的に成功したロードで onLoad が発火するまでスケルトンは表示され続ける。
+ * 遷移中に画像要素自体がアンマウント→リマウントされるケース（View Transition時の二重フェッチなど）では、
+ * このコンポーネントごと再マウントされ isLoaded は false から始まり直すが、
+ * ブラウザキャッシュ済みの画像は ref コールバックで complete を同期検知してスケルトンを描画せずスキップする
+ * （ペイント前に isLoaded が true になるため、キャッシュ済み画像の再マウントでちらつかない）。
  * また、同一インスタンスのまま src だけが差し替わるケース（将来カルーセル等で再利用される場合）に備え、
  * src の変化を検知して isLoaded を明示的にリセットする。
  *
- * 既知の制約: 初回SSR＋ハイドレーション時、ブラウザが画像を実際には表示可能な状態にしていても、
- * isLoaded は React のハイドレーションが完了し onLoad 相当の処理が走るまで false のままになる。
+ * placeholder="blur" が渡された場合はスケルトンを重ねない。ぼかし画像自体が
+ * 読み込み中の表示として機能し、JSの状態管理に依存せずペイント直後から表示されるため
+ * （ハイドレーション前でもプレースホルダーが出る点でスケルトンより堅牢）。
+ *
+ * 既知の制約: 初回SSR＋ハイドレーション時（キャッシュ未ヒット時）、isLoaded は React の
+ * ハイドレーションが完了し onLoad 相当の処理が走るまで false のままになる。
  * 通常の環境ではハイドレーションは数百ms以内に完了するため体感できる問題にならないが、
  * 極端に低スペックな端末やCPUが逼迫した状況ではスケルトンが数秒残る可能性がある。
- * これは「画像自体のopacityを操作しない（LCP計測に影響しない）」設計とのトレードオフであり、
- * onLoad/refコールバックのタイミングはNext.js側のハイドレーション完了に依存するため
- * このコンポーネント内だけでは解消できない（next/imageのownRefコールバックもハイドレーション後にしか走らない）。
+ * これは「画像自体のopacityを操作しない（LCP計測に影響しない）」設計とのトレードオフ。
  */
 const ImageWithSkeleton = ({
   skeletonClassName = "",
@@ -44,9 +47,24 @@ const ImageWithSkeleton = ({
   onError,
   alt,
   src,
+  placeholder,
   ...restProps
 }: ImageWithSkeletonProps) => {
-  const [isLoaded, setIsLoaded] = useState(false);
+  // blurプレースホルダー使用時はスケルトンを描画しないため、isLoadedをtrueで初期化して
+  // 以降のsetIsLoaded(true)をReactのbail-out(同値set)にし、無駄な再レンダーを避ける
+  const [isLoaded, setIsLoaded] = useState(placeholder === "blur");
+  // ブラウザキャッシュ済みで既に描画可能な画像を、マウント時(コミットフェーズ)に同期検知する。
+  // ルート遷移で再マウントされた場合にonLoadを待つと、キャッシュ済み画像でも
+  // スケルトンが一瞬表示され(さらにフェードアウトに500msかかり)ちらつきになるため。
+  // refコールバック内のsetStateはペイント前に再レンダーされるので、completeが同期的に
+  // trueになる環境(Chromiumで実測済み)ではスケルトンは一度も描画されない。
+  // 仕様上completeの同期更新は保証されないが、falseだった場合も従来どおり
+  // onLoad経由でスケルトンが解除されるだけで退行はしない
+  const handleRef = useCallback((node: HTMLImageElement | null) => {
+    if (node?.complete && node.naturalWidth > 0) {
+      setIsLoaded(true);
+    }
+  }, []);
   // src が差し替わった場合（同一インスタンスがキーを変えずに再利用されるケース）に
   // スケルトンを再表示できるよう、レンダー中に前回の src と比較して isLoaded を調整する
   // （React公式が推奨する「レンダー中の状態調整」パターン。useEffectだと1フレーム遅れて
@@ -77,23 +95,42 @@ const ImageWithSkeleton = ({
     [onError]
   );
 
+  // blurプレースホルダー指定時は、ぼかし画像自体が読み込み中の表示として機能するため
+  // グレーのスケルトンは重ねない（blurの上にスケルトンを被せると明滅してちらつく）
+  const showSkeleton = placeholder !== "blur";
+
   const content = (
     <>
       <Image
         {...restProps}
+        // src変更時はImageごと再マウントする。next/image内部のblurComplete stateは
+        // srcが変わってもリセットされないため、同一インスタンスのままsrcだけ差し替えると
+        // blurプレースホルダーが2枚目以降で表示されなくなる(handleRefの再実行もこれで担保)。
+        // StaticImport(静的import画像)の場合も内包するURLをkeyに使う
+        key={
+          typeof src === "string"
+            ? src
+            : "default" in src
+              ? src.default.src
+              : src.src
+        }
+        ref={handleRef}
         src={src}
         alt={alt}
+        placeholder={placeholder}
         onLoad={handleLoad}
         onError={handleError}
       />
-      <span
-        aria-hidden="true"
-        className={cltw(
-          "pointer-events-none absolute inset-0 bg-gray-200 transition-opacity duration-500 ease-out dark:bg-gray-600",
-          isLoaded ? "opacity-0" : "animate-pulse opacity-100",
-          skeletonClassName
-        )}
-      />
+      {showSkeleton && (
+        <span
+          aria-hidden="true"
+          className={cltw(
+            "pointer-events-none absolute inset-0 bg-gray-200 transition-opacity duration-500 ease-out dark:bg-gray-600",
+            isLoaded ? "opacity-0" : "animate-pulse opacity-100",
+            skeletonClassName
+          )}
+        />
+      )}
     </>
   );
 

--- a/src/components/ZennArticleList/index.tsx
+++ b/src/components/ZennArticleList/index.tsx
@@ -29,7 +29,8 @@ const ZennArticleList = async ({ locale, keyword }: ZennArticleListProps) => {
   }
   return (
     // NOTE: フッターの位置を調整するため、mb-[101px]を追加
-    <nav className="opacity-0 animate-fadeIn mb-[101px]">
+    // (フェードイン演出は遷移のたびに再生されちらつくため付けない)
+    <nav className="mb-[101px]">
       <ul className="m-0 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
         {filteredData.slice(0, 6).map(({ link, title, isoDate }, index) => (
           <ZennArticleItem key={index} link={link} title={title} date={isoDate} keyword={keyword} />

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -39,9 +39,7 @@ summary:focus-visible,
   outline-color: #2F8F9D; /* primary */
 }
 
-/* View Transitions API のクロスフェード/モーフの質感調整。
-   (*) はrootを含む全ての名前付きグループに一致するため、
-   ページ全体のデフォルト遷移にも一貫して適用される */
+/* View Transitions API のモーフ(サムネイル等の名前付きグループ)の質感調整 */
 ::view-transition-group(*) {
   animation-duration: 450ms;
   animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
@@ -49,6 +47,26 @@ summary:focus-visible,
 ::view-transition-old(*),
 ::view-transition-new(*) {
   animation-duration: 300ms;
+}
+
+/* ルート(ページ全体)はクロスフェードさせず即時切替にする。
+   デフォルトの全画面フェードは遷移のたびにヘッダー含む画面全体が明滅して
+   「ちらつき」に見えるため無効化し、名前付きグループのモーフだけを残す。
+   mix-blend-mode: normal はChromiumではアニメーション経由で配信されるplus-lighterが
+   animation: none で一緒に消えるため冗長だが、他エンジンでスナップショットが
+   加算合成(白飛び)されないことを保証するための明示 */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+/* rootのグループアニメーション(-ua-view-transition-group-anim-root)も止める。
+   放置すると上の group(*) ルールにより450ms走り続け、スクロールバー有無等で
+   新旧rootのキャプチャサイズが異なる環境ではフェードに隠されない歪みが見える上、
+   モーフの無い遷移でもView Transitionの寿命を450msに引き延ばしてしまう */
+::view-transition-group(root) {
+  animation: none;
 }
 
 /* reduced-motion ユーザーには全アニメ・トランジションを止める */

--- a/src/util/__tests__/index.spec.ts
+++ b/src/util/__tests__/index.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { thumbnailPlaceholderProps } from '@/util';
+
+describe('thumbnailPlaceholderProps', () => {
+  it('blurDataURLがある場合はplaceholder="blur"とblurDataURLを返す', () => {
+    const dataUrl = 'data:image/webp;base64,UklGRiIAAABXRUJQVlA4TBUAAAAvY8AYAAfQ/4j+B/Cg2f8zLNL/VAA=';
+    expect(thumbnailPlaceholderProps(dataUrl)).toEqual({
+      placeholder: 'blur',
+      blurDataURL: dataUrl,
+    });
+  });
+
+  it('blurDataURLが無い/空の場合はplaceholder="empty"へフォールバックする（blurDataURL無しのplaceholder="blur"はnext/imageがエラーにするため）', () => {
+    expect(thumbnailPlaceholderProps(undefined)).toEqual({ placeholder: 'empty' });
+    expect(thumbnailPlaceholderProps('')).toEqual({ placeholder: 'empty' });
+  });
+});

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -17,3 +17,14 @@ export const calcDiffYears = (date: string) => {
   const diffMs = new Date().getTime() - new Date(date).getTime();
   return Math.floor(diffMs / (365.25 * 24 * 60 * 60 * 1000));
 }
+
+// Veliteがビルド時に生成したblurDataURLをnext/imageのプレースホルダーに変換する。
+// blurプレースホルダーはハイドレーション不要でペイント直後から表示されるため、
+// 遷移時にグレーのスケルトンが明滅するちらつきが発生しない。
+// blurDataURLはVeliteのスキーマ上必須だが、万一空だった場合にplaceholder="blur"のまま
+// blurDataURL無しでnext/imageに渡すとエラーになるため"empty"へフォールバックする
+export const thumbnailPlaceholderProps = (blurDataURL: string | undefined) => {
+  return blurDataURL
+    ? { placeholder: "blur" as const, blurDataURL }
+    : { placeholder: "empty" as const };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,10 +10,9 @@ const config: Config = {
   theme: {
     extend: {
       keyframes: {
-        fadeInAnime: {
-          '0%': { opacity: '0', transform: 'translateY(-4px)' },
-          '100%': { opacity: '1', transform: 'translateY(0)' },
-        },
+        // NOTE: かつて記事一覧等で使っていた fadeInAnime(animate-fadeIn)は削除済み。
+        // ルート遷移で再マウントされる要素に入場フェードを付けると、View Transitionの
+        // スナップショットがopacity:0で撮られ遷移のたびにちらつくため再導入しないこと
         fadeIn: {
           '0%': {
             opacity: '0',
@@ -26,7 +25,6 @@ const config: Config = {
         },
       },
       animation: {
-        'fadeIn': 'fadeInAnime 0.45s ease-out forwards',
         'fade-in': 'fadeIn 0.2s ease-out',
       },
       textUnderlineOffset: {


### PR DESCRIPTION
## 概要

ページ遷移(一覧→詳細、ページネーション、About等)のたびに画像や画面全体がちらつく問題を修正します。

## 原因(3つの重なり)

1. **View Transitionの全画面クロスフェード** — `::view-transition-old/new(*)` がrootも対象で、全遷移でヘッダー含む画面全体が300〜450ms明滅
2. **`animate-fadeIn`の毎回再生** — 遷移毎にopacity:0から再生され、VTスナップショットが「透明なコンテンツ」で撮られる。さらにreduced-motion環境ではdurationのみ0.01msに縮みstagger遅延が残るため、カードが順にポップ出現する別種のちらつきも発生
3. **画像スケルトンの毎回再表示** — 再マウントのたびキャッシュ済みでもグレーのパルスが挟まる

## 変更内容

- `custom.css`: rootのクロスフェードを無効化(old/new + group。group(root)を放置すると `-ua-view-transition-group-anim-root` が450ms走り続けることを実測で確認)。`mix-blend-mode: normal` を他エンジン向けに明示。サムネイルのモーフ(`thumb-{slug}`)は維持
- 一覧・About・Zenn一覧から `animate-fadeIn` を除去、tailwindの死んだ定義も削除+再導入禁止コメント
- 記事サムネイルにVeliteビルド時生成の `blurDataURL` を採用(`thumbnailPlaceholderProps` ヘルパーに集約)。blur時はスケルトン非表示
- `ImageWithSkeleton`: キャッシュ済み画像のref同期検知、src変更時の再マウント(`key`)、blur経路の無駄な再レンダー解消
- blur経路+ヘルパーのユニットテスト追加(65→69件)

## 検証

- 本番ビルドで一覧→詳細/戻る/ページネーション/About/Zennタブの全遷移をブラウザ実測(遷移中サンプリングでスケルトン0・フェードイン0、サムネイルモーフ動作維持を確認)
- reduced-motion有効/無効の両経路で確認
- xhighレベルのマルチエージェントコードレビュー実施(11件検出→10件修正、plus-lighter白飛び等6候補は対照実験で反証)
- `tsc --noEmit` / vitest 69件 / lint / `npm run build` すべて✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SChtuzN4hQUhdTwE2QePgD