### PR TITLE
post: Next.js個人ブログのLCP改善記事 (nextjs-lcp-improvement)

### DIFF
--- a/content/blogs/nextjs-lcp-improvement/index.en.mdx
+++ b/content/blogs/nextjs-lcp-improvement/index.en.mdx
@@ -1,0 +1,225 @@
+---
+title: "How I Cut My Next.js Blog's Mobile LCP from 17.4 Seconds (the Culprit Wasn't Images)"
+description: "My Next.js personal blog (Cloudflare Workers / OpenNext) had a mobile LCP as bad as 17.4 seconds. The culprit wasn't images — it was render-blocking CSS and every article's body leaking into the client bundle. A record of hunting each cause down with real traces and getting production LCP to 3.7–4.3s. A Core Web Vitals improvement story."
+publishedAt: "2026-07-09T00:56:30.609Z"
+updatedAt: "2026-07-09T00:56:30.609Z"
+categories:
+  - next_js
+related:
+  - microcms-to-mdx-migration
+  - my-seo-todo-list
+draft: false
+---
+
+Hello! I'm [@Ryo54388667](https://x.com/Ryo54388667)!☺️
+
+I work as an engineer in Tokyo, mostly writing TypeScript and Next.js.
+
+Today I'll share **how I cut my personal blog's mobile LCP down from 17.4 seconds**!
+
+I'll confess up front: when I started, I was convinced that "slow LCP = the hero image is heavy." LCP is the Core Web Vital where the image usually plays the lead role, so I get why I assumed that — but as I hunted down the culprits one by one, almost everything that actually moved the needle turned out to be somewhere other than images. If you're wrestling with LCP on a similar stack (Next.js + Cloudflare Workers), I hope this helps.
+
+## What Was Going On
+
+One day I ran Lighthouse (mobile) on the article detail pages, and the scores were red across the board. The worst page came in at LCP 17.4s / Performance 58. On mobile, almost every detail page was in the red.
+
+Here's the stack. Pretty typical, I think.
+
+- Next.js 16.2.3 (App Router / Turbopack)
+- Deployed on Cloudflare Workers (`@opennextjs/cloudflare`)
+- Articles are MDX + Velite (all compiled to typed JSON at build time)
+- Measurement baseline: Lighthouse mobile (Slow 4G + 4x CPU throttling)
+
+This blog itself had [just moved from microCMS to MDX](/en/blogs/next_js/microcms-to-mdx-migration) not long ago, so I hadn't gotten around to performance yet. Still, 17.4 seconds is rough. "I'll just make the images lighter," I thought casually — and that was the start of a long detour...
+
+## When I Couldn't Trust the Numbers (simulated vs. real trace, off by 10x)
+
+This is what tripped me up first. Same page, but the numbers were wildly different depending on how I measured.
+
+- Lighthouse (simulated): LCP 8–17s
+- Chrome DevTools real trace (Performance panel, Slow 4G + 4x CPU): LCP 1.4s
+
+Line them up and they're off by nearly 10x. "Which one am I supposed to believe?"
+
+Digging in, the Cloudflare Workers origin TTFB was swinging between 0.28 and 1.05 seconds, and Lighthouse's simulated model was amplifying that variance in its estimate. One page showed 8.0s in simulated, but in a real trace it was LCP 1,445ms (TTFB 253ms + render delay 1,192ms) — no problem at all.
+
+So I switched my approach. **Don't trust the absolute values from the simulated run.** Use the score as a directional signal, and pin down the culprit from the real-trace breakdown — that's what I decided.
+
+By the way, the 17.4 seconds from the top is a simulated score too. The real-world LCP was probably a bit faster, but I've decided to treat the mobile Lighthouse score as my metric, so a red score is a problem worth fixing in itself.
+
+An LCP breaks down into four phases: TTFB / Load delay / Load duration / Render delay. If "the image has already arrived but nothing paints," Render delay grows — so looking there tells you "this isn't the image, it's the paint being blocked." Production TTFB fluctuates, so measuring several times (instead of getting jerked around by a single outlier) mattered too.
+
+## First I Went After the Images (but this was just the opening act)
+
+With the approach settled, I started with images by the book. The small Next.js gotchas I hit here were fun in their own right, so I'll leave them in.
+
+The first thing that snagged me was `fetchPriority`. The LCP image's request was starting at `initial priority: Low` for some reason. I had a memory that setting `priority` used to auto-apply `fetchpriority="high"`...
+
+Half in disbelief, I grepped `node_modules/next/dist/shared/lib/get-img-props.js` directly to check. Sure enough, there's no code that sets `'high'`. It turns out the auto-coupling between `priority` and `fetchpriority="high"` was removed a while back (mid-2024), and even passing `preload` — the successor to `priority` introduced in Next 16 — won't apply `fetchpriority` unless you set it yourself. In the end I had to pass it explicitly.
+
+```tsx title="ArticleBody/index.tsx"
+<ImageWithSkeleton
+  src={data.thumbnail.src}
+  loading="eager"
+  preload
+  fetchPriority="high"   // won't be applied unless you set it explicitly
+/>
+```
+
+Framework updates sometimes silently drop things they used to do for you. When something feels off, reading the implementation in `node_modules` is honestly the fastest route — that got reconfirmed.
+
+Next, image sizing. Because I'd mechanically slapped `sizes="100vw"` on everything, an author icon that actually renders at 80px was fetching the `w=1536` variant (spotted in DevTools' Network tab). I rewrote `sizes` to match the real render width, and added AVIF to `images.formats` in `next.config.mjs` (10–30% smaller than WebP).
+
+And one landmine. `src/app/icon.png` was being served as 1024×1024 / 1.4MB, and that single file took up half the total transfer size. Shrank it to 96×96, 2.4KB.
+
+But this "well-intentioned optimization" caused a little accident later. Because the favicon URL changed, Google re-evaluated it, and since the classic `/favicon.ico` was a 404, the favicon in search results turned into a globe icon. I sorted it out by providing a multi-size `favicon.ico`, but it was a textbook case of a perf fix having side effects elsewhere (I've also written up the finer SEO details in [another article](/en/blogs/next_js/my-seo-todo-list)).
+
+And after all that, here's what I realized. Images barely moved the needle.
+
+## The Real Story: What Was Killing LCP Wasn't Images 💡
+
+Looking at the detail page's LCP breakdown in a real trace again, Render delay was eating 2.9 seconds. The image was long since downloaded, yet it couldn't paint. So the culprit is something blocking rendering.
+
+### The Render-Blocking Font CSS (and How Inlining It Made Things Slower)
+
+The first thing I found was the `@font-face` CSS that `next/font/google` (Kosugi Maru) generates. At 90KB raw / 33KB compressed, split across 121 unicode-range subsets, this CSS was being emitted by Turbopack as a standalone render-blocking CSS chunk on every page. In a real trace, out of an LCP of 3,866ms, Render delay was 2,978ms. The RenderBlocking insight estimated up to 2.4s of improvement. This was the guy.
+
+"If it's render-blocking, I'll just inline the CSS, right?" — so I enabled Next.js's `experimental.inlineCss` and ran an A/B. Here's the result.
+
+| | FCP | Perf |
+|---|---|---|
+| External CSS chunk (original) | 2.4s | 72 |
+| inlineCss=true | 4.7s | 63 |
+
+It got clearly worse. The huge Japanese-font `@font-face` definitions got duplicated into every page's HTML, making the HTML heavier to transfer and parse. The external chunk, which benefits from edge caching and reuse across pages, is faster. A nice lesson that the textbook move isn't always right. The failure itself became material, so I'll call it a win. 😅
+
+In the end, I split the `@font-face` definitions out into a static file at a version-pinned URL, and insert the stylesheet dynamically via script. A stylesheet inserted this way isn't render-blocking by spec. I also delay the insertion until after the load event, so the font woff2 doesn't fight the LCP image for bandwidth.
+
+```tsx title="app/layout.tsx"
+const FONT_CSS_PATH = "/fonts/kosugi-maru-v17.css";
+
+// preload itself isn't render-blocking, so just kick off the fetch early
+<link rel="preload" href={FONT_CSS_PATH} as="style" />
+<Script id="load-font-css" strategy="beforeInteractive"
+  dangerouslySetInnerHTML={{ __html:
+    `(function(){function f(){var l=document.createElement('link');` +
+    `l.rel='stylesheet';l.href='${FONT_CSS_PATH}';document.head.appendChild(l)}` +
+    `document.readyState==='complete'?f():window.addEventListener('load',f)})()`
+  }}
+/>
+```
+
+While the font isn't loaded, it renders with a `size-adjust`ed fallback (reusing the values next/font had generated), so CLS stays at 0. This part matters more than it looks, so I was careful not to break it.
+
+### Every Article's Body Was in the Client Bundle
+
+This is the one that hit hardest.
+
+The production detail pages were shipping a giant JS chunk — hundreds of KB even after compression — shared across every page. "It's probably `react-syntax-highlighter` or `react-tweet` or `katex`," I assumed, and grepped the chunk — zero hits for any of those library names. What showed up instead were the strings `"body":"..."`, `"raw":"..."`, `"plainText":"..."`, 62 times each. The actual body text of a vacuum-cleaner review and the CMS-migration article.
+
+Here's the truth: **the full text of all 62 articles (31 each in Japanese and English) was sitting in the client bundle, raw, at 2.4MB.** That's 441KB gzipped, 266KB even with brotli.
+
+Tracing the cause, an article card (a client component) was importing a single pure function — just to derive a category slug — from `@/lib/content`.
+
+```tsx title="ArticleCard.tsx"
+"use client";
+// this single import pulls all of content.ts (= every article's data) into the client chunk
+import { getPrimaryCategoryIdFromBlogPost } from "@/lib/content";
+```
+
+The top of `@/lib/content` is `import { blogs } from "#content/index"` — a module that loads every article's data, `body`/`raw` included. Turbopack wasn't tree-shaking this per export; it was pulling the whole module into the shared client chunk.
+
+The fix is simple: split the pure functions that don't depend on `#content` into a separate file.
+
+```tsx title="ArticleCard.tsx"
+// keep only the helpers that don't depend on the all-articles JSON, in content-utils.ts
+import { getPrimaryCategoryIdFromBlogPost } from "@/lib/content-utils";
+```
+
+With that, the detail page's total JS transfer dropped from ~900KB to 268KB. In the App Router, a client component importing a server-only module in a single line puts all the data that module pulls in into the bundle. A JSON import doesn't disappear via tree-shaking. Put pure functions in a file free of `#content` — I burned that into muscle memory.
+
+### Even With a Narrowed Type, the RSC Payload Leaks
+
+Even after fixing the bundle, there was still a leak. I only noticed it when a reviewer pointed it out: the props I passed to the client component were typed as `Pick<BlogPost, ...>`, but the object I was actually passing was the full `BlogPost` (body/raw/plainText included).
+
+```tsx title="ArticleList/index.tsx"
+// the type is a Pick, but item is the full BlogPost. body/raw ride along in the flight payload
+<ArticleCard data={item} />
+
+// narrow the actual object before it crosses the boundary
+<ArticleCard data={toBlogPostSummary(item)} />
+```
+
+Even if you think you've narrowed it with a TypeScript type, if the runtime object is full, the article's entire text gets serialized into the RSC flight payload (the HTML). **Narrowing the type doesn't narrow the object.** When handing data from server to client, I had to build a new object with only the needed fields and drop the rest at the object level.
+
+Checking is easy: `curl -s <page> | grep '"raw"'` should return zero. With this, the list page's HTML shrank from 349KB raw to 110KB, and the detail page from 141KB to 107KB.
+
+### Deprioritizing the Third-Party GTM
+
+Last, Google Tag Manager. `@next/third-parties`' `GoogleTagManager` is fixed to `afterInteractive`, and gtm.js (127KB, High priority) was fighting the render-blocking CSS and LCP image for Slow 4G bandwidth. Since it's a component whose strategy you can't override, I wrote the official snippet myself and moved it to `lazyOnload` (after the load event + requestIdleCallback).
+
+To be honest, this is a trade-off. Page views from ultra-fast users who leave before load slip out of the measurement. I accepted it as the price of performance — prioritizing paint over measurement completeness.
+
+## Cloudflare Workers (OpenNext)-Specific Gotchas
+
+From here on it's heavily environment-dependent, so this is a bonus for people using Cloudflare Workers / OpenNext.
+
+Because the list and category pages referenced `searchParams`, every request became dynamically rendered, was served with `Cache-Control: no-store`, and even the browser's back/forward (bfcache) was disabled. I separated search into a dedicated dynamic route and made the list side static — but removing `searchParams` alone didn't make it static, and the culprit turned out to be next-intl's request-scoped locale resolution. I fixed it by explicitly setting `force-static`.
+
+One more: after I added `redirects` for old-URL compatibility, it worked fine under `next start`, but on OpenNext (workerd) every page got redirected to the search page. The cause was that OpenNext's routing layer evaluates a `has` query with no `value` as "always matches."
+
+```js title="next.config.mjs"
+// without value, OpenNext always matches (redirects even with no query)
+has: [{ type: 'query', key: 'keyword' }]
+// require it to be non-empty
+has: [{ type: 'query', key: 'keyword', value: '.+' }]
+```
+
+Redirects and caching behave differently between `next start` and OpenNext (workerd). It's best to always verify on a production-equivalent environment.
+
+## Results (Before / After)
+
+Lighthouse mobile trend for the article detail pages.
+
+| Phase | Perf | LCP |
+|---|---|---|
+| Before (when the issue surfaced) | 52–79 | 4.8–17.4s |
+| After everything (local production build) | 92–97 | 2.7–3.6s |
+| After everything (production) | 80–87 | 3.7–4.3s |
+
+Just the numbers:
+
+- Total transfer: 2,915KiB → ~950KiB (about -68%)
+- List page HTML: 349KB raw → 110KB
+- Detail page total JS: ~900KB → 268KB
+- Gone from the client: every article's body (2.4MB raw)
+- CLS: held at 0
+
+The score variance, which had been swinging ±20 with TTFB, converged to about ±3 on the local production build. On production the TTFB still fluctuates, so one run occasionally throws an outlier.
+
+## Wrapping Up
+
+That was long, but the one thing I most want to get across is: LCP isn't just an image problem. Looking back, what worked wasn't image optimization but untangling, one at a time, the fights over bandwidth and the main thread happening around it.
+
+Here are the lessons that stuck.
+
+- LCP is a mixed martial art. Render-blocking CSS, giant bundles, RSC payloads, third-party JS — anything that steals the critical path counts.
+- The App Router's client boundary leaks at the "object" level. Both imports and props — even if you narrow the type, a full object rides along.
+- Don't take simulated numbers at face value; pin down the culprit from the real-trace breakdown. Measure several times on production.
+- The textbook move (inlining) isn't always right. Always A/B it.
+- Verify deploy-environment-specific traps on a production-equivalent setup. OpenNext behaves differently from `next start`.
+
+If you're stuck on "LCP is slow, but I already made the images lighter," try looking at Render delay in a real trace once. The culprit might be somewhere else entirely.
+
+If you know a better way, please let me know~
+
+Thank you for reading to the end!
+
+I tweet casually, so please feel free to follow me! 🥺
+
+## References
+
+- [Optimize Largest Contentful Paint (web.dev)](https://web.dev/articles/optimize-lcp)
+- [next/font - Next.js Docs](https://nextjs.org/docs/app/api-reference/components/font)
+- [Window: requestIdleCallback() - MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback)
+- [OpenNext for Cloudflare](https://opennext.js.org/cloudflare)

--- a/content/blogs/nextjs-lcp-improvement/index.ja.mdx
+++ b/content/blogs/nextjs-lcp-improvement/index.ja.mdx
@@ -1,0 +1,225 @@
+---
+title: "Next.js個人ブログのモバイルLCPを17.4秒から改善した話(犯人は画像じゃなかった)"
+description: "モバイルLCPが最悪17.4秒だったNext.js個人ブログ(Cloudflare Workers / OpenNext)。犯人は画像ではなく、render-blockingなCSSやクライアントバンドルへの記事本文の混入でした。実トレースで一つずつ潰し、LCPを本番3.7〜4.3秒まで改善した、Core Web Vitals改善の記録です。"
+publishedAt: "2026-07-09T00:56:30.609Z"
+updatedAt: "2026-07-09T00:56:30.609Z"
+categories:
+  - next_js
+related:
+  - microcms-to-mdx-migration
+  - my-seo-todo-list
+draft: false
+---
+
+こんにちは！[@Ryo54388667](https://x.com/Ryo54388667)です！☺️
+
+普段は都内でエンジニアをやっていて、TypeScriptとNext.jsばかり触っています。
+
+今回は **個人ブログのモバイルLCPを17.4秒から改善した話** を紹介していきます！
+
+先に白状しておくと、直し始めたときの僕は「LCPが遅い＝ヒーロー画像が重いんでしょ」と思い込んでいました。LCPはCore Web Vitalsの中でも画像が主役になりがちな指標ですが、実際に犯人を一つずつ潰していったら、効いたのはほとんど画像以外のところでした。同じような構成(Next.js + Cloudflare Workers)でLCPに悩んでいる方の参考になればうれしいです。
+
+## 何が起きていたか
+
+ある日、記事詳細ページにLighthouse(mobile)をかけたら、スコアが軒並み赤い。一番ひどいページで LCP 17.4秒 / Performance 58 でした。モバイル基準だとほぼ全ての詳細ページが赤字です。
+
+環境はこんな感じです。ありがちな構成だと思います。
+
+- Next.js 16.2.3(App Router / Turbopack)
+- デプロイ先は Cloudflare Workers(`@opennextjs/cloudflare`)
+- 記事は MDX + Velite(ビルド時に全記事を型付きJSONへ変換)
+- 計測基準は Lighthouse mobile(Slow 4G + 4x CPUスロットリング)
+
+このブログ自体、少し前に[microCMSからMDXへ移行したばかり](/ja/blogs/next_js/microcms-to-mdx-migration)で、まだ性能まで手が回っていない状態でした。とはいえ17.4秒はさすがにひどい。「画像を軽くすればいけるやろ」と軽い気持ちで着手したのが、長い回り道の始まりでした。。
+
+## 計測が信じられなかった(simulatedと実トレースが10倍違う)
+
+最初にハマったのがこれです。同じページなのに、計測方法で数字が全然違う。
+
+- Lighthouse(simulated):LCP 8〜17秒
+- Chrome DevToolsの実トレース(Performanceパネル、Slow 4G + 4x CPU):LCP 1.4秒
+
+並べてみると、10倍近く違うんですよね。「どっちを信じればええねん」となりました。
+
+原因を掘っていくと、Cloudflare WorkersのオリジンTTFBが 0.28〜1.05秒の間で振れていて、Lighthouseのsimulatedモデルがこの変動を増幅して見積もっていました。実際、あるページはsimulatedで8.0秒と出ていたのに、実トレースで見ると LCP 1,445ms(TTFB 253ms + レンダー遅延1,192ms)で、何の問題もありませんでした。
+
+ここで方針を切り替えます。**simulatedの絶対値は信じない**。スコアの傾向を見る指標として使い、犯人の特定は実トレースの内訳でやる、と決めました。
+
+ちなみに冒頭の17.4秒も、このsimulatedのスコアです。実際のLCPはもう少し速かったはずですが、僕はモバイルのLighthouseスコアを指標にすると決めているので、スコアが赤いこと自体は直すべき問題でした。
+
+LCPの内訳は TTFB / Load delay / Load duration / Render delay の4フェーズに分かれます。「画像はもう届いているのに描画されない」なら Render delay が大きくなるので、そこを見れば「これは画像じゃなくて描画のブロックだな」と読めます。本番はTTFBが振れるので、1回の外れ値に振り回されないよう複数回計測するのも大事でした。
+
+## まず画像から手をつけた(でも、ここは前座だった)
+
+方針は決まったものの、まずは定石どおり画像から潰していきました。ここで踏んだNext.jsの小さな落とし穴が、それはそれで面白かったので残しておきます。
+
+まず引っかかったのが `fetchPriority` でした。LCP画像のリクエストが、なぜか `initial priority: Low` で始まっている。昔は `priority` を付ければ `fetchpriority="high"` が自動で付いていた記憶があったんですが。。
+
+半信半疑だったので、`node_modules/next/dist/shared/lib/get-img-props.js` を直接grepして確かめてみました。すると確かに `'high'` を設定するコードが無い。調べると `priority` と `fetchpriority="high"` の自動連動は少し前(2024年半ば)に外されていて、Next 16で `priority` の後継として入った `preload` を渡しても、`fetchpriority` は自分で指定しないと付かない状態でした。結局、明示的に渡す必要があったんですね。
+
+```tsx title="ArticleBody/index.tsx"
+<ImageWithSkeleton
+  src={data.thumbnail.src}
+  loading="eager"
+  preload
+  fetchPriority="high"   // 明示しないと付かない
+/>
+```
+
+フレームワークの更新で、今まで自動でやってくれていたことが黙って外れることがあります。「おかしいな」と思ったら `node_modules` の実装を読みにいくのが結局いちばん早い、というのを再確認しました。
+
+次に画像のサイズです。`sizes="100vw"` を機械的に付けていたせいで、実際は80pxでしか表示されない著者アイコンが `w=1536` のバリアントを取得していました(DevToolsのNetworkで発覚)。コンテナの実表示幅に合わせて `sizes` を書き直し、あわせて `next.config.mjs` の `images.formats` にAVIFを足しました(WebP比で1〜3割減)。
+
+そして地雷が一つ。`src/app/icon.png` が 1024×1024 / 1.4MB のまま配信されていて、これ単体で総転送量の半分を占めていました。96×96に縮小して 2.4KB に。
+
+ところがこの「良かれと思った最適化」が、後日ちょっとした事故を生みます。faviconのURLが変わったことでGoogleが再評価に入り、しかも定番の `/favicon.ico` が404だったせいで、検索結果のファビコンが地球儀アイコンに化けました。マルチサイズの `favicon.ico` を用意して事なきを得ましたが、性能改善が別の面に副作用を出す典型例でした(SEO周りの細かい話は[別記事](/ja/blogs/next_js/my-seo-todo-list)にもまとめています)。
+
+で、ここまでやって気づくんです。画像、たいして効いてないぞ、と。
+
+## 本題:LCPを殺していたのは画像じゃなかった 💡
+
+実トレースで詳細ページのLCP内訳をあらためて見ると、Render delayが2.9秒を占めていました。画像はとっくにDL済みなのに描画できていない。つまり犯人はレンダリングをブロックしている何かです。
+
+### render-blockingなフォントCSS(と、インライン化して逆に遅くなった話)
+
+まず見つかったのが `next/font/google`(Kosugi Maru)が生成する `@font-face` 定義CSSでした。生90KB・圧縮33KB、121個のunicode-rangeサブセットに分かれたこのCSSが、Turbopackでは独立したrender-blocking CSSチャンクとして全ページに出力されていました。実トレースでLCP 3,866msのうちRender delayが2,978ms。RenderBlockingインサイトの推定改善は最大2.4秒。犯人はこいつです。
+
+「render-blockingなら、CSSをインライン化すればいいんじゃない?」と考えて、Next.jsの `experimental.inlineCss` を有効にしてA/Bを取ってみました。結果はこうです。
+
+| | FCP | Perf |
+|---|---|---|
+| 外部CSSチャンク(元) | 2.4s | 72 |
+| inlineCss=true | 4.7s | 63 |
+
+見事に悪化しました。日本語フォントの巨大な `@font-face` 定義が全ページのHTMLに複製されて、HTMLの転送とパースが重くなったんですね。エッジキャッシュとページ間の再利用が効く外部チャンクの方が速い。定石が正解とは限らない、という良い教訓でした。この失敗自体がネタになったので、まあ良しとします😅
+
+最終的には、`@font-face` 定義をバージョン固定URLの静的ファイルに切り出し、scriptで動的にstylesheetを挿入する形にしました。挿入されたstylesheetは仕様上render-blockingになりません。さらにloadイベント後まで挿入を遅らせて、フォントのwoff2がLCP画像と帯域を奪い合うのも避けています。
+
+```tsx title="app/layout.tsx"
+const FONT_CSS_PATH = "/fonts/kosugi-maru-v17.css";
+
+// preload自体はrender-blockingしないので、fetchだけ先に始めておく
+<link rel="preload" href={FONT_CSS_PATH} as="style" />
+<Script id="load-font-css" strategy="beforeInteractive"
+  dangerouslySetInnerHTML={{ __html:
+    `(function(){function f(){var l=document.createElement('link');` +
+    `l.rel='stylesheet';l.href='${FONT_CSS_PATH}';document.head.appendChild(l)}` +
+    `document.readyState==='complete'?f():window.addEventListener('load',f)})()`
+  }}
+/>
+```
+
+フォント未ロードの間は `size-adjust` 済みのフォールバック(next/fontが生成していた値を流用)で描画されるので、CLSは0のまま維持できています。ここ、意外と大事なので崩さないように気をつけました。
+
+### クライアントバンドルに全記事の本文が入っていた
+
+これが今回いちばん刺さったやつです。
+
+本番の詳細ページに、圧縮後でも数百KBの巨大JSチャンクが全ページ共通で配信されていました。「どうせ `react-syntax-highlighter` か `react-tweet` か `katex` あたりでしょ」と高を括って該当チャンクをgrepしたら、これらのライブラリ名は0件。代わりに出てきたのが `"body":"..."` `"raw":"..."` `"plainText":"..."` という文字列が、それぞれ62回。掃除機レビュー記事やCMS移行記事の本文テキストそのものでした。
+
+正体はこれです。**全62記事(日英31本ずつ)の本文が、生2.4MBのままクライアントバンドルにまるごと入っていた**。gzipで441KB、brotliでも266KBです。
+
+原因をたどると、記事カード(client component)が、カテゴリslugを求めるためだけの純粋関数を1つ `@/lib/content` からimportしていました。
+
+```tsx title="ArticleCard.tsx"
+"use client";
+// このimport1行で、content.ts丸ごと(= 全記事データ)がクライアントチャンク化される
+import { getPrimaryCategoryIdFromBlogPost } from "@/lib/content";
+```
+
+`@/lib/content` の先頭は `import { blogs } from "#content/index"`、つまり全記事の `body`/`raw` 込みのデータを読み込むモジュールです。Turbopackはこれをexport単位ではtree-shakeしてくれず、モジュール全体をクライアント共有チャンクに含めてしまっていました。
+
+解決は単純で、`#content` に依存しない純粋関数だけを別ファイルに切り出すだけです。
+
+```tsx title="ArticleCard.tsx"
+// 全記事JSONに依存しないヘルパーだけを content-utils.ts に分離
+import { getPrimaryCategoryIdFromBlogPost } from "@/lib/content-utils";
+```
+
+これで詳細ページのJS転送合計が、約900KB → 268KBまで落ちました。App Routerでは、client componentがサーバー専用モジュールを1行importするだけで、そのモジュールが取り込む全データがバンドルに乗ります。JSONのimportはtree-shakingで消えてくれない。純粋関数は `#content` 非依存のファイルに置く、というのを体に刻みました。
+
+### 型で絞ってもRSCペイロードには漏れる
+
+バンドルを直しても、まだ漏れ道が残っていました。レビューで指摘されて気づいたんですが、client componentへ渡すpropsの型は `Pick<BlogPost, ...>` で絞っていたのに、渡している実体はフルの `BlogPost`(body/raw/plainText込み)だったんです。
+
+```tsx title="ArticleList/index.tsx"
+// 型はPickでも、itemはフルのBlogPost。flightにbody/rawが乗る
+<ArticleCard data={item} />
+
+// 境界を越える前に「実体」を絞る
+<ArticleCard data={toBlogPostSummary(item)} />
+```
+
+TypeScriptの型で絞ったつもりでも、実行時のオブジェクトがフルなら、RSCのflightペイロード(HTML)に記事全文がシリアライズされます。**型で絞っても、実体は漏れる**。サーバーからクライアントへ渡すときは、必要フィールドだけの新しいオブジェクトを作って実体レベルで落とす必要がありました。
+
+検査は簡単で、`curl -s <page> | grep '"raw"'` が0件になっていればOKです。これで一覧ページのHTMLが生349KB → 110KB、詳細も141KB → 107KBまで軽くなりました。
+
+### サードパーティのGTMを後回しにする
+
+最後にGoogle Tag Manager。`@next/third-parties` の `GoogleTagManager` は `afterInteractive` 固定で、gtm.js(127KB・High優先度)がrender-blocking CSSやLCP画像とSlow 4Gの帯域を奪い合っていました。strategyを上書きできないコンポーネントなので、公式スニペットを自前で書いて `lazyOnload`(loadイベント後 + requestIdleCallback)に寄せました。
+
+正直に書くと、これはトレードオフです。loadより前に離脱した超速ユーザーのPVは計測から漏れます。性能とのバーターとして許容しました。計測の完全性より、まず描画を優先する判断です。
+
+## Cloudflare Workers(OpenNext)特有のハマりどころ
+
+ここからは環境依存が強いので、Cloudflare Workers / OpenNextを使っている人向けのおまけです。
+
+一覧・カテゴリページが `searchParams` を参照していたせいで全リクエストが動的レンダリングになり、`Cache-Control: no-store` で配信されて、ブラウザの戻る/進む(bfcache)まで無効になっていました。検索を動的専用ルートに分離して一覧側を静的化したのですが、`searchParams` を外すだけでは静的化せず、犯人はnext-intlのリクエストスコープなlocale解決だった、というオチもありました。`force-static` を明示して解決しています。
+
+もう一つ、旧URL互換のために `redirects` を足したら、`next start` では正常なのにOpenNext(workerd)だと全ページが検索ページにリダイレクトされる事故が起きました。原因は、OpenNextのルーティング層が `has` の `value` 未指定を「常にマッチ」と評価することでした。
+
+```js title="next.config.mjs"
+// valueなしだとOpenNextでは常時マッチ(クエリが無くてもリダイレクト)
+has: [{ type: 'query', key: 'keyword' }]
+// 非空を明示する
+has: [{ type: 'query', key: 'keyword', value: '.+' }]
+```
+
+リダイレクトやキャッシュ周りは、`next start` とOpenNext(workerd)で挙動が違います。本番相当の環境で必ず実機検証したほうがいいです。
+
+## 結果(Before / After)
+
+記事詳細ページのLighthouse mobileの推移です。
+
+| フェーズ | Perf | LCP |
+|---|---|---|
+| 改善前(issue発覚時) | 52〜79 | 4.8〜17.4s |
+| 全対応後(ローカル本番ビルド) | 92〜97 | 2.7〜3.6s |
+| 全対応後(本番) | 80〜87 | 3.7〜4.3s |
+
+数字だけ拾うと、こんな感じでした。
+
+- 総転送量:2,915KiB → 約950KiB(約-68%)
+- 一覧ページのHTML:生349KB → 110KB
+- 詳細ページのJS合計:約900KB → 268KB
+- クライアントから消えたもの:全記事の本文(生2.4MB)
+- CLS:0を維持
+
+スコアの分散も、TTFBの振れで±20動いていたのが、ローカル本番ビルドでは±3くらいに収束しました。本番だと相変わらずTTFBが振れるので、1runだけ外れ値が出ることはあります。
+
+## 最後に
+
+長々と書きましたが、今回いちばん伝えたいのは「LCPは画像だけの問題じゃない」ということです。振り返ってみると、効いたのは画像最適化ではなく、その周りにあった帯域とメインスレッドの奪い合いを一つずつ解いたことでした。
+
+やってみて残った学びを並べておきます。
+
+- LCPは総合格闘技。render-blocking CSS・巨大バンドル・RSCペイロード・サードパーティJSまで、クリティカルパスを奪うものは全部効く
+- App Routerのclient境界は「実体」で漏れる。importもpropsも、型で絞っても実体がフルなら乗ってしまう
+- 計測はsimulatedを鵜呑みにせず、実トレースの内訳で犯人を特定する。本番は複数回
+- 定石(インライン化)が正解とは限らない。必ずA/Bで計測する
+- デプロイ環境特有の罠は本番相当で検証する。OpenNextは `next start` と挙動が違う
+
+同じように「LCPが遅い、でも画像は軽くしたはずなのに」で悩んでいる方は、一度実トレースでRender delayを見てみてください。犯人が別のところにいるかもしれません。
+
+より良い方法があれば教えてください〜
+
+最後まで読んでいただきありがとうございます！
+
+気ままにつぶやいているので、気軽にフォローをお願いします！🥺
+
+## 参考資料
+
+- [Optimize Largest Contentful Paint (web.dev)](https://web.dev/articles/optimize-lcp)
+- [next/font - Next.js Docs](https://nextjs.org/docs/app/api-reference/components/font)
+- [Window: requestIdleCallback() - MDN](https://developer.mozilla.org/ja/docs/Web/API/Window/requestIdleCallback)
+- [OpenNext for Cloudflare](https://opennext.js.org/cloudflare)


### PR DESCRIPTION
## 概要

Next.js 16 + Cloudflare Workers(OpenNext)の個人ブログで、モバイルLCPが最悪17.4秒だった問題を、Lighthouseの実トレースで犯人を特定して改善した記録記事です。ja/en 両方を追加します。

- カテゴリ: `next_js`
- slug: `nextjs-lcp-improvement`
- related: `microcms-to-mdx-migration`, `my-seo-todo-list`

## 記事の要点

- 効いたのは画像最適化ではなく、render-blockingなフォントCSS・クライアントバンドルへの全記事本文の混入・RSCペイロード漏れ・GTMの帯域競合
- 計測はsimulatedを鵜呑みにせず実トレースの内訳(TTFB / Load delay / Render delay)で犯人特定
- 結果: 詳細ページの Lighthouse mobile が Perf 52〜79 → 92〜97(ローカル本番ビルド)、LCP 4.8〜17.4s → 2.7〜3.6s

## チェック

- [x] `npm run lint:content` 通過(内部リンク・textlint・markdownlint・velite build)
- [x] 秘匿情報スキャン(scan_secrets.py)clean(CRITICAL/WARNING/TRIAGE すべて0)
- [x] 品質レビュー(blog-editor-in-chief)+ 事実確認レビュー実施、指摘反映済み
- [x] ja/en の frontmatter 整合(categories / publishedAt / related / draft)
- [x] `draft: false`
- 画像なし(サムネイル未設定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)