### PR TITLE
docs: READMEにslack-claude-responderによる監視の記載を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ This project no longer requires any CMS API keys. See `.dev.vars.example` for th
 https://github.com/ryota-09/ryota-blog-infra
 
 For more details about the frontend part of `Ryota Blog`, refer to the official documentation or comments within the repository. If you have any questions or need support, create an issue or contact the maintainers.
+
+This repository is monitored by slack-claude-responder.


### PR DESCRIPTION
## 概要
README.md の末尾に「This repository is monitored by slack-claude-responder.」の一文を追加しました。

## 変更理由
Slackからの依頼(問い合わせID: C0BGAUDSQ07)に基づく、READMEへの一文追加。

## テスト
ドキュメントのみの変更のため、ビルド・lint・テストは未実施(コード・型定義への影響なし)。

---
🤖 このPRは slack-claude-responder が Slack の依頼から自動生成しました。
- 依頼者: U074XTVLX0A / チャンネル: C0BGAUDSQ07 / スレッド: 1783846935.602169
- 変更ファイル: 1件

⚠️ **マージ前に必ず人間がレビューしてください。**