### PR TITLE
perf: もしもウィジェットをIntersectionObserverで遅延初期化しLCP帯域を保護

### DIFF
--- a/e2e/moshimo-lazy.spec.ts
+++ b/e2e/moshimo-lazy.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// もしもアフィリエイトウィジェットを9個含む記事(遅延初期化の検証対象)。
+// 公開済み記事のURLは維持される運用のため、特定slugへの依存は安定している
+const MOSHIMO_ARTICLE_PATH = '/ja/blogs/zakki/best-buy-2026-first-half';
+
+// もしも関連の外部リクエスト(bundle.js・Amazon商品画像)のURLパターン
+const MOSHIMO_RESOURCE_PATTERN = /msmstatic\.com|media-amazon\.com/;
+
+// ページ内のもしも関連リクエストを記録するリスナーを仕掛ける
+const trackMoshimoRequests = (page: Page): string[] => {
+  const requests: string[] = [];
+  page.on('request', (req) => {
+    if (MOSHIMO_RESOURCE_PATTERN.test(req.url())) {
+      requests.push(req.url());
+    }
+  });
+  return requests;
+};
+
+test.describe('もしもウィジェットの遅延初期化(ExecutableScript lazyRootMargin)', () => {
+  test('MOSHIMO-01: 初期ロードではもしも関連の外部リクエストが発生しない', async ({ page }) => {
+    const moshimoRequests = trackMoshimoRequests(page);
+
+    await page.goto(MOSHIMO_ARTICLE_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // ウィジェットのプレースホルダー自体はSSRで9個描画されている
+    await expect(page.locator('[id^="msmaflink-"]')).toHaveCount(9);
+
+    // ファーストビュー外のウィジェットは初期化されず、bundle.js・商品画像とも未取得
+    expect(moshimoRequests).toHaveLength(0);
+  });
+
+  test('MOSHIMO-02: ウィジェットへスクロールすると初期化され描画される', async ({ page }) => {
+    const moshimoRequests = trackMoshimoRequests(page);
+
+    await page.goto(MOSHIMO_ARTICLE_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // 最初のウィジェットの位置までスクロールするとIntersectionObserverが発火する
+    await page.locator('[id^="msmaflink-"]').first().scrollIntoViewIfNeeded();
+
+    // bundle.jsが描画するカルーセル本体(.easyLink-box)の出現を待つ
+    await expect(page.locator('.easyLink-box').first()).toBeVisible({ timeout: 15000 });
+
+    // bundle.jsと1枚目の商品画像が取得されている
+    expect(moshimoRequests.some((url) => url.includes('msmstatic.com'))).toBe(true);
+    expect(moshimoRequests.some((url) => url.includes('media-amazon.com'))).toBe(true);
+  });
+
+  test('MOSHIMO-03: 記事末尾までスクロールすると全ウィジェットが描画される', async ({ page }) => {
+    await page.goto(MOSHIMO_ARTICLE_PATH);
+    await page.waitForLoadState('networkidle');
+
+    // 実ユーザーのスクロールを模して段階的に最下部まで移動する
+    // (一気に飛ぶと中間のウィジェットのIntersectionObserverが発火しないため)
+    const totalHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+    const viewport = page.viewportSize()?.height ?? 720;
+    for (let y = 0; y < totalHeight; y += viewport) {
+      await page.evaluate((top) => window.scrollTo(0, top), y);
+      await page.waitForTimeout(200);
+    }
+
+    // 9個すべてのウィジェットが描画される(bundle.jsは描画済みdivのidに-1を付けてリネームする)
+    await expect(page.locator('.easyLink-box')).toHaveCount(9, { timeout: 15000 });
+  });
+
+  test('MOSHIMO-04: ソフトナビゲーションで遷移してもウィジェットが描画される', async ({ page }) => {
+    // 一覧ページからLinkクリックでSPA遷移する(f0b1eb5の合成loadディスパッチのリグレッション防止)
+    await page.goto('/ja/blogs');
+    await page.waitForLoadState('networkidle');
+
+    const articleLink = page.locator(`a[href*="best-buy-2026-first-half"]`).first();
+    await expect(articleLink).toBeVisible();
+    await articleLink.click();
+
+    // SPA遷移完了(記事タイトル表示)を待つ
+    await expect(page).toHaveURL(new RegExp('best-buy-2026-first-half'));
+    await expect(page.locator('h1').first()).toBeVisible();
+
+    // ウィジェットへスクロールして描画されることを確認する
+    await page.locator('[id^="msmaflink-"]').first().scrollIntoViewIfNeeded();
+    await expect(page.locator('.easyLink-box').first()).toBeVisible({ timeout: 15000 });
+  });
+});

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,13 @@ const withBundleAnalyzer = withBundleAnalyzerFactory({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  // git worktree(リポジトリ内サブディレクトリ)でビルドしても .next/standalone/server.js の
+  // 位置が変わらないよう、ファイルトレース・Turbopackのルートをこのプロジェクト自身に固定する
+  // (要: worktree自身のnode_modules。親リポジトリのnode_modules頼みだとビルドが失敗する)
+  outputFileTracingRoot: import.meta.dirname,
+  turbopack: {
+    root: import.meta.dirname,
+  },
   // NOTE: experimental.inlineCss はA/B計測の結果、不採用(Issue #223)。
   // render-blocking監査は解消するが、日本語フォントの@font-face CSS(生90KB)が
   // 全ページのHTMLに複製されてFCPが2.4s→4.7s、Perfスコアが72→63に悪化した。

--- a/src/components/ArticleBody/Embeds/MoshimoAffiliate/index.tsx
+++ b/src/components/ArticleBody/Embeds/MoshimoAffiliate/index.tsx
@@ -26,7 +26,13 @@ const MoshimoAffiliate = ({ widget }: MoshimoAffiliateProps) => {
 
   return (
     <aside className="my-4">
-      <ExecutableScript attribs={{ type: "text/javascript" }} code={code} />
+      {/* ビューポート1画面分手前まで初期化を遅延し、bundle.js+商品画像(各ウィジェット1枚目)の
+          取得を初期ロードのLCP帯域から退避させる。ファーストビュー内のウィジェットは即初期化される */}
+      <ExecutableScript
+        attribs={{ type: "text/javascript" }}
+        code={code}
+        lazyRootMargin="800px 0px"
+      />
       <div id={`msmaflink-${widget.eid}`}>リンク</div>
     </aside>
   );

--- a/src/components/ArticleBody/RichEditor/ExecutableScript/index.tsx
+++ b/src/components/ArticleBody/RichEditor/ExecutableScript/index.tsx
@@ -6,6 +6,9 @@ type ExecutableScriptProps = {
   attribs: Record<string, string>;
   // 元のscriptタグのインラインコード（外部scriptの場合は空文字）
   code: string;
+  // 指定時、親要素がビューポートに接近(rootMargin指定分の手前)するまでスクリプト実行を遅延する。
+  // 外部リソースを大量に取得する埋め込み(もしも等)を初期ロードのLCP帯域から退避させるために使う
+  lazyRootMargin?: string;
 };
 
 // もしもアフィリエイト(かんたんリンク)のローダーがbundle.jsのscript要素に付与するID
@@ -28,8 +31,12 @@ const prepareMoshimoBatch = () => {
     moshimoBatchStarted = false;
   });
   bundleExistedBeforeBatch = !!document.getElementById(MOSHIMO_LOADER_ID);
-  // 前のページで積まれた未処理のキューが残っていると、bundle.jsが古いエントリを
-  // 再処理して重複描画や例外を起こすため、このページ分を積む前に破棄する
+  // 前のページで積まれた処理済み・未処理のキューが残っていると、bundle.jsが古いエントリを
+  // 再処理して重複描画や例外を起こすため、このページ分を積む前に破棄する。
+  // ただしトリガー待ち(スケジュール済み)のキューは、遅延初期化で直前に発火した
+  // 別ウィジェットの処理前エントリなので破棄してはいけない(破棄するとそのウィジェットが
+  // 永久に描画されない。E2E: moshimo-lazy.spec.ts MOSHIMO-03で回帰検知)
+  if (moshimoTriggerScheduled) return;
   const loader = window.msmaflink;
   if (loader && Array.isArray(loader.q)) {
     loader.q.length = 0;
@@ -65,35 +72,63 @@ const scheduleMoshimoTrigger = () => {
 // そのため本文中のscriptタグをこのコンポーネントに置き換え、マウント時にDOM APIで
 // script要素を生成し直して実行させる。ソフトナビゲーションで記事へ遷移した場合も
 // 再マウントされるため、ハードナビゲーションと同様にウィジェット等が描画される
-const ExecutableScript = ({ attribs, code }: ExecutableScriptProps) => {
+const ExecutableScript = ({ attribs, code, lazyRootMargin }: ExecutableScriptProps) => {
   const anchorRef = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
     const anchor = anchorRef.current;
     if (!anchor || !anchor.parentNode) return;
 
-    const isMoshimo = code.includes(MOSHIMO_LOADER_ID);
-    if (isMoshimo) {
-      prepareMoshimoBatch();
+    // 遅延実行時はクリーンアップ時点でscript未挿入の可能性があるため、参照をクロージャで持つ
+    let script: HTMLScriptElement | null = null;
+
+    const execute = () => {
+      const isMoshimo = code.includes(MOSHIMO_LOADER_ID);
+      if (isMoshimo) {
+        prepareMoshimoBatch();
+      }
+
+      const element = document.createElement("script");
+      Object.entries(attribs).forEach(([name, value]) => {
+        element.setAttribute(name, value);
+      });
+      if (code) {
+        element.text = code;
+      }
+      // bundle.jsは「script要素の直後の兄弟がウィジェット本体かどうか」を重複描画ガードに
+      // 使っているため、ラッパー内ではなく元のscriptタグと同じ位置(anchorの直後)に挿入する
+      anchor.parentNode?.insertBefore(element, anchor.nextSibling);
+      script = element;
+
+      if (isMoshimo) {
+        scheduleMoshimoTrigger();
+      }
+    };
+
+    if (!lazyRootMargin || typeof IntersectionObserver === "undefined") {
+      execute();
+      return () => {
+        script?.remove();
+      };
     }
 
-    const script = document.createElement("script");
-    Object.entries(attribs).forEach(([name, value]) => {
-      script.setAttribute(name, value);
-    });
-    if (code) {
-      script.text = code;
-    }
-    // bundle.jsは「script要素の直後の兄弟がウィジェット本体かどうか」を重複描画ガードに
-    // 使っているため、ラッパー内ではなく元のscriptタグと同じ位置(anchorの直後)に挿入する
-    anchor.parentNode.insertBefore(script, anchor.nextSibling);
-
-    if (isMoshimo) {
-      scheduleMoshimoTrigger();
-    }
+    // 遅延実行: 埋め込みがビューポートに接近(rootMargin分手前)して初めてスクリプトを実行する。
+    // 外部リソース(もしものbundle.js+商品画像等)を初期ロードのLCP帯域から退避させるのが目的。
+    // anchor自身はサイズ0のspanのため、描画先divを含む親要素を観測して交差判定を確実にする
+    const target = anchor.parentElement ?? anchor;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        observer.disconnect();
+        execute();
+      },
+      { rootMargin: lazyRootMargin },
+    );
+    observer.observe(target);
 
     return () => {
-      script.remove();
+      observer.disconnect();
+      script?.remove();
     };
     // 同一インスタンスの再レンダリングで重複実行しないよう、マウント時のみ実行する
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## 概要

記事詳細ページのLighthouseスコア(mobile)改善対応です。もしもアフィリエイトウィジェットを多数含む記事(例: [best-buy-2026-first-half](https://ryotablog.jp/ja/blogs/zakki/best-buy-2026-first-half)、ウィジェット9個)で、ページロード直後にもしものbundle.js 50KB + Amazon商品画像9枚(約218KB・計16リクエスト)が一斉取得され、LCP画像と帯域競合していました。本番計測は Performance 78 / LCP 4.8s(LCPスコア0.31が最大の失点)。

ウィジェットを「ビューポート800px手前に接近して初めて初期化する」遅延方式に変更し、初期ロードからもしも関連リクエストを完全に排除しました(総転送量 1.18MB → 961KB)。

## 変更内容

- **ExecutableScript**: `lazyRootMargin` propを追加。指定時はIntersectionObserverで親要素のビューポート接近までスクリプト実行を遅延。未指定の呼び出しは従来通り即時実行
- **MoshimoAffiliate**: `lazyRootMargin="800px 0px"` で遅延を有効化
- **キュー破棄のレース条件修正**: 個別発火化で「ウィジェットAの未処理キューエントリを、直後に発火したBの破棄処理が消してしまい、Aが永久に未描画になる」競合が顕在化(新規E2Eが3ブラウザ一貫で9個中8個描画を検知)。トリガー待ち中は破棄をスキップするよう修正
- **E2E追加**(`e2e/moshimo-lazy.spec.ts`): 初期リクエストゼロ / スクロール初期化 / 全9ウィジェット描画 / ソフトナビゲーション遷移後の描画(f0b1eb5の合成loadディスパッチ回帰防止)を3ブラウザで検証
- **next.config.mjs**: worktreeビルドでstandalone出力位置が壊れないよう `outputFileTracingRoot` / `turbopack.root` をプロジェクト自身に固定(本番挙動への影響なし)

## 検証

- 新規E2E: **12/12パス**(chromium / firefox / webkit)
- 既存E2E: **190 passed**、回帰なし
- lint 0エラー / tsc 0エラー / Vitest 76/76
- ローカルLighthouse(mobile・ウォーム計測): もしも関連リクエスト 11本218KB → **0本**

## 補足(計測について)

- ローカルのウォーム計測ではスコアは前後同値(92)。ローカルは実効帯域が広くload後リソースがlantern LCPに乗らないため、スコアへの効果は**デプロイ後に本番計測(`measure.mjs --prod`)で確認**が必要です(本番ベースライン: 78)
- スコアに現れない場合でも、実ユーザーのモバイル回線では「読まれない可能性のある記事下部のための218KB先払い」が消えるため、体感・CrUXには確実にプラスです
- 調査過程の副産物: ビルド直後1回目のローカル計測はコールドスタートで大幅に悪く出る(同一ビルドで60→92)ため、前後比較は2回目以降のウォーム値で行う運用としました

🤖 Generated with [Claude Code](https://claude.com/claude-code)