### PR TITLE
middleware.ts → proxy.ts へ規約移行(Next.js 16非推奨警告対応)

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -19,7 +19,9 @@ export default defineCloudflareConfig({
     tagCache: d1NextTagCache,
   }),
   // ISR/SSGキャッシュヒット時にNextServerの起動を丸ごとスキップして直接レスポンスを返す。
-  // middleware(next-intlロケール解決・AIアクセス計測・adminのBasic認証)は
-  // interceptionより必ず前に実行されるため影響なし(@opennextjs/aws routingHandlerで確認済み)
+  // proxy(next-intlロケール解決・AIアクセス計測・adminのBasic認証、旧middleware.tsから移行)は
+  // interceptionより必ず前に実行されるため影響なし(@opennextjs/aws routingHandlerで確認済み。
+  // ビルド後はNext.js側でproxy.js→middleware.jsへリネームされるため@opennextjs/cloudflare 1.20.1側の
+  // 変更は不要。node_modules/next/dist/build/index.js の該当箇所で確認)
   enableCacheInterception: true,
 });

--- a/scripts/migration/check-b-redirects.mjs
+++ b/scripts/migration/check-b-redirects.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // B. 旧URLリダイレクト(stg)
-// middleware.ts / next.config.mjs のリダイレクトルールが stg 上で期待通り動くかを検証する。
+// proxy.ts / next.config.mjs のリダイレクトルールが stg 上で期待通り動くかを検証する。
 
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";

--- a/src/app/route.ts
+++ b/src/app/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// middleware.ts:51-59 が "/" を常に先取りしてリダイレクトするため、通常はこのハンドラーに
-// 到達しない。OpenNext/Cloudflareが静的アセットを直接返す等でmiddlewareを迂回した場合の
+// proxy.ts:51-59 が "/" を常に先取りしてリダイレクトするため、通常はこのハンドラーに
+// 到達しない。OpenNext/Cloudflareが静的アセットを直接返す等でproxyを迂回した場合の
 // セーフティネットとして残す(旧 src/app/page.tsx の代替。route.tsはpage.tsxと異なりroot
 // layoutを必要としないため、layout.tsxを[locale]配下へ統合した後もこのファイルは独立して残せる)
 export function GET(request: NextRequest) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,7 +10,7 @@ import { recordAiAccessHit } from './lib/ai-access/repository'
 import type { AiBotDefinition } from './lib/ai-access/types'
 // NOTE: 旧URL(/blogs/{slug})のカテゴリ解決用の軽量静的マップ(slug×locale→プライマリカテゴリid)。
 // Veliteのcomplete フック(velite.config.ts)がビルド時に生成する。記事本文は含まないため、
-// これをmiddlewareがimportしてもバンドルサイズへの影響は軽微(数KB)。
+// これをproxyがimportしてもバンドルサイズへの影響は軽微(数KB)。
 import categoryMap from '../.velite/category-map.json'
 
 const CATEGORY_SLUGS = CATEGORIES.map((category) => category.slug)
@@ -35,7 +35,7 @@ const ADMIN_PATH_PATTERN = /^\/[^/]+\/admin(\/.*)?$/
 // Create the intl middleware
 const intlMiddleware = createMiddleware(routing);
 
-export async function middleware(request: NextRequest, event: NextFetchEvent) {
+export async function proxy(request: NextRequest, event: NextFetchEvent) {
   const pathname = request.nextUrl.pathname;
 
   // 管理者ページはBasic認証で保護する

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -146,9 +146,9 @@ export default defineConfig({
     }
   },
   complete: (data, { config }) => {
-    // middleware.ts の旧URL(/blogs/{slug})リダイレクト用に、
+    // proxy.ts の旧URL(/blogs/{slug})リダイレクト用に、
     // 「slug×locale → プライマリカテゴリid」の軽量マップを別ファイルとして書き出す。
-    // middlewareのバンドルに記事本文(body/raw/plainText等)が混入しないよう、
+    // proxyのバンドルに記事本文(body/raw/plainText等)が混入しないよう、
     // .velite/blogs.json (全フィールド込み・約2.3MB) は直接importさせない。
     const categoryMap: Record<string, Record<string, string>> = { ja: {}, en: {} };
     for (const blog of data.blogs) {


### PR DESCRIPTION
## 概要
`src/middleware.ts` を `src/proxy.ts` にリネームし、Next.js 16の新ファイル規約(`middleware` → `proxy`)に対応。ビルド時に出ていた非推奨警告を解消する。

Closes #292

## 変更点
- `src/middleware.ts` → `src/proxy.ts`、エクスポート関数名 `middleware` → `proxy`
- ファイル名を参照していたコメントを更新(`open-next.config.ts` / `velite.config.ts` / `src/app/route.ts` / `scripts/migration/check-b-redirects.mjs`)

## 依存バージョン確認
同一バージョン(next 16.2.10 / next-intl 4.13.2 / @opennextjs/cloudflare 1.20.1)がインストール済みの環境でNext.js本体のソースを確認:
- `proxy.ts`はビルド後に内部で`proxy.js`→`middleware.js`へリネームされ、OpenNextが読む`.next`成果物の構造は従来通り。`@opennextjs/cloudflare`のバージョンアップは不要。
- `proxy.ts`のexport名は`proxy`である必要がある(Next.js本体のテンプレートで確認)。
- next-intlの`createMiddleware`はファイル名・export名に依存しないため変更不要。

## テスト結果
- `npm run lint`: 0 errors
- `npx tsc --noEmit`: エラーなし
- `npx vitest run`: 76 tests passed
- `npm run build`: 未実施(実行環境の制約)

## 未実施の検証
issueが必須とする`preview:stg`(wrangler/workerd実機)でのロケールリダイレクト・cache interception・admin 401・AIアクセス計測・has条件付きredirectsの確認は、このジョブ環境では未実施。マージ前に実機検証をお願いします。

---
🤖 このPRは slack-claude-responder が Slack の依頼から自動生成しました。
- 依頼者: U074XTVLX0A / チャンネル: C0BGAUDSQ07 / スレッド: 1784027252.478009
- 変更ファイル: 5件

⚠️ **マージ前に必ず人間がレビューしてください。**