### PR TITLE
fix(deploy): proxy.ts→middleware.ts へ戻して本番デプロイ復旧(Edge middleware)

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -19,9 +19,7 @@ export default defineCloudflareConfig({
     tagCache: d1NextTagCache,
   }),
   // ISR/SSGキャッシュヒット時にNextServerの起動を丸ごとスキップして直接レスポンスを返す。
-  // proxy(next-intlロケール解決・AIアクセス計測・adminのBasic認証、旧middleware.tsから移行)は
-  // interceptionより必ず前に実行されるため影響なし(@opennextjs/aws routingHandlerで確認済み。
-  // ビルド後はNext.js側でproxy.js→middleware.jsへリネームされるため@opennextjs/cloudflare 1.20.1側の
-  // 変更は不要。node_modules/next/dist/build/index.js の該当箇所で確認)
+  // middleware(next-intlロケール解決・AIアクセス計測・adminのBasic認証)は
+  // interceptionより必ず前に実行されるため影響なし(@opennextjs/aws routingHandlerで確認済み)
   enableCacheInterception: true,
 });

--- a/scripts/migration/check-b-redirects.mjs
+++ b/scripts/migration/check-b-redirects.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // B. 旧URLリダイレクト(stg)
-// proxy.ts / next.config.mjs のリダイレクトルールが stg 上で期待通り動くかを検証する。
+// middleware.ts / next.config.mjs のリダイレクトルールが stg 上で期待通り動くかを検証する。
 
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";

--- a/src/app/route.ts
+++ b/src/app/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// proxy.ts:51-59 が "/" を常に先取りしてリダイレクトするため、通常はこのハンドラーに
-// 到達しない。OpenNext/Cloudflareが静的アセットを直接返す等でproxyを迂回した場合の
+// middleware.ts:51-59 が "/" を常に先取りしてリダイレクトするため、通常はこのハンドラーに
+// 到達しない。OpenNext/Cloudflareが静的アセットを直接返す等でmiddlewareを迂回した場合の
 // セーフティネットとして残す(旧 src/app/page.tsx の代替。route.tsはpage.tsxと異なりroot
 // layoutを必要としないため、layout.tsxを[locale]配下へ統合した後もこのファイルは独立して残せる)
 export function GET(request: NextRequest) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,13 @@
+// ⚠️ このファイルは意図的に `middleware.ts` 規約のまま維持している(proxy.ts へ改名しないこと)。
+// 理由: Next.js 16 の新 `proxy.ts` 規約は、ビルド時に必ず Node.js ランタイムのミドルウェアとして
+// 出力される(next/dist/build/entries.js の runDependingOnPageType: isProxyFile → onServer() 固定で
+// Edge にする分岐が無い)。一方 `middleware.ts` は既定で Edge ランタイムになる。
+// @opennextjs/cloudflare(現行 1.20.1)は Node.js ミドルウェアを未サポートで、Node 判定だと
+// `opennextjs-cloudflare build` が "Node.js middleware is not currently supported" で exit 1 になり
+// 本番デプロイ(Cloudflare Workers)が停止する(実績: PR #303, 2026-07-17)。
+// Next.js 16 は `middleware.ts` に対して非推奨"警告"を出すが、警告 < 本番停止 であり、
+// opennextjs-cloudflare が Node プロキシに対応する(upstream)まではこの規約を維持する。
+// 経緯: #292 で proxy.ts へ改名(dccb865)→ 本番デプロイが落ちたため revert。
 import { NextResponse } from 'next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 import createMiddleware from 'next-intl/middleware';
@@ -10,7 +20,7 @@ import { recordAiAccessHit } from './lib/ai-access/repository'
 import type { AiBotDefinition } from './lib/ai-access/types'
 // NOTE: 旧URL(/blogs/{slug})のカテゴリ解決用の軽量静的マップ(slug×locale→プライマリカテゴリid)。
 // Veliteのcomplete フック(velite.config.ts)がビルド時に生成する。記事本文は含まないため、
-// これをproxyがimportしてもバンドルサイズへの影響は軽微(数KB)。
+// これをmiddlewareがimportしてもバンドルサイズへの影響は軽微(数KB)。
 import categoryMap from '../.velite/category-map.json'
 
 const CATEGORY_SLUGS = CATEGORIES.map((category) => category.slug)
@@ -35,7 +45,7 @@ const ADMIN_PATH_PATTERN = /^\/[^/]+\/admin(\/.*)?$/
 // Create the intl middleware
 const intlMiddleware = createMiddleware(routing);
 
-export async function proxy(request: NextRequest, event: NextFetchEvent) {
+export async function middleware(request: NextRequest, event: NextFetchEvent) {
   const pathname = request.nextUrl.pathname;
 
   // 管理者ページはBasic認証で保護する

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -146,9 +146,9 @@ export default defineConfig({
     }
   },
   complete: (data, { config }) => {
-    // proxy.ts の旧URL(/blogs/{slug})リダイレクト用に、
+    // middleware.ts の旧URL(/blogs/{slug})リダイレクト用に、
     // 「slug×locale → プライマリカテゴリid」の軽量マップを別ファイルとして書き出す。
-    // proxyのバンドルに記事本文(body/raw/plainText等)が混入しないよう、
+    // middlewareのバンドルに記事本文(body/raw/plainText等)が混入しないよう、
     // .velite/blogs.json (全フィールド込み・約2.3MB) は直接importさせない。
     const categoryMap: Record<string, Record<string, string>> = { ja: {}, en: {} };
     for (const blog of data.blogs) {


### PR DESCRIPTION
Cloudflare本番デプロイ(PR #303, 2026-07-17)が
`opennextjs-cloudflare build` の "Node.js middleware is not currently supported" で停止した問題の恒久対応。

真因: #292 で middleware.ts→proxy.ts へ改名した(dccb865)が、Next.js 16 は proxy.ts を必ず Node.js ランタイムのミドルウェアとして出力する
(next/dist/build/entries.js runDependingOnPageType: isProxyFile→onServer() 固定、Edge分岐なし)。middleware.ts は既定でEdge。
@opennextjs/cloudflare 1.20.1(最新)は Node.js ミドルウェア未対応のため build時にexit 1となり、フォールバック(wrangler直deploy)も同ビルドで失敗していた (CIの "R2 #1284" 警告は失敗理由の決め打ち出力で、実際の原因はこれ)。

対応: dccb865 を revert して middleware.ts 規約(Edge)へ戻す。runtime指定では 解決不可(proxy.tsにEdge分岐が存在しない)。Next 16 の非推奨"警告"は復活するが、 警告 < 本番停止。opennextがNodeプロキシ対応するまで本規約を維持する旨を
middleware.ts 冒頭に明記し再発を防止。

検証: ローカル next build で .next/server/middleware-manifest.json に middleware["/"](=Edge)が生成され、opennextの useNodeMiddleware() が false を 返す(=エラーにならない)ことを確認済み。