### PR TITLE
fix: 「テスト」カテゴリのIDをtest→testingへ改名し仮値との衝突を解消

### DIFF
--- a/content/blogs/jstqb-foundation-study-method/index.en.mdx
+++ b/content/blogs/jstqb-foundation-study-method/index.en.mdx
@@ -4,7 +4,7 @@ description: A pass report for the JSTQB Foundation Level (CTFL) after 1.5 month
 publishedAt: "2026-07-04T05:06:27.606Z"
 updatedAt: "2026-07-04T05:06:27.606Z"
 categories:
-  - test
+  - testing
 thumbnail: ./images/jstqb_fl_thumbnail.jpeg
 related:
   - saa-c03-failed

--- a/content/blogs/jstqb-foundation-study-method/index.ja.mdx
+++ b/content/blogs/jstqb-foundation-study-method/index.ja.mdx
@@ -4,7 +4,7 @@ description: JSTQB Foundation Level（CTFL）に1ヶ月半の勉強で合格し�
 publishedAt: "2026-07-04T04:40:13.955Z"
 updatedAt: "2026-07-04T04:44:30.539Z"
 categories:
-  - test
+  - testing
 thumbnail: ./images/jstqb_fl_thumbnail.jpeg
 related:
   - saa-c03-failed

--- a/content/categories.json
+++ b/content/categories.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": "test",
+    "id": "testing",
     "name": "テスト",
-    "name_en": "test",
+    "name_en": "Testing",
     "icon": "./images/categories/gemini-svg.svg",
     "bg_color": "#FFEC89"
   },

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -14,6 +14,7 @@ npm run new-post -- <slug>
 - `slug` は英小文字・数字・ハイフンのみ(URL `/{locale}/blogs/{category}/{slug}` にそのまま使われる)
 - 既に同名の記事ディレクトリが存在する場合は中断する(誤って上書きしない)
 - 生成直後は `draft: true` になっている(下記「2. draft運用」を参照)
+- `categories` は `__REPLACE_ME__` という仮値になっている。`content/categories.json` に実在するidへ必ず差し替えること(veliteは素の文字列としか検証しないため差し替え忘れはビルドで落ちない。ただし公開URLに仮値がそのまま出るので目視で気付ける)
 
 生成後の流れ:
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -60,6 +60,40 @@ const nextConfig = {
   },
   async redirects() {
     return [
+      // --- カテゴリID改名の互換リダイレクト: test → testing (2026-07-27) ---
+      // 「テスト」カテゴリのidが `npm run new-post` の仮値プレースホルダー `test` と文字列衝突しており、
+      // 「本物のQA記事」と「カテゴリ差し替え忘れ」を機械でも人間でも判別できなかったため改名した。
+      // 記事詳細ページはURLのカテゴリセグメントと実カテゴリの不一致を notFound() にする実装
+      // (src/app/[locale]/blogs/[category]/[blogId]/page.tsx)なので、旧URLは明示的に301で受ける必要がある。
+      // NOTE: 予約セグメント page は先に個別ルールで拾ってから :blogId に流す。
+      {
+        source: '/:locale(ja|en)/blogs/test/page/:page',
+        destination: '/:locale/blogs/testing/page/:page',
+        permanent: true,
+      },
+      {
+        source: '/:locale(ja|en)/blogs/test/:blogId((?!page$)[^/]+)',
+        destination: '/:locale/blogs/testing/:blogId',
+        permanent: true,
+      },
+      {
+        source: '/:locale(ja|en)/blogs/test',
+        destination: '/:locale/blogs/testing',
+        permanent: true,
+      },
+      // ロケール無しの旧URL形式。改名で `test` がカテゴリ既知セグメント(middlewareのNON_BLOG_ID_SEGMENTS)から
+      // 外れたため、これが無いと /blogs/test はmiddlewareの「記事が見つからない」分岐で /ja/blogs へ流れてしまう。
+      // 実測(next dev): 本ルールが先に評価され、6形式すべて308で新URLへ到達することを確認済み
+      {
+        source: '/blogs/test/:blogId((?!page$)[^/]+)',
+        destination: '/ja/blogs/testing/:blogId',
+        permanent: true,
+      },
+      {
+        source: '/blogs/test',
+        destination: '/ja/blogs/testing',
+        permanent: true,
+      },
       // Redirect /blogs/page to /blogs
       {
         source: '/blogs/page',

--- a/scripts/new-post.mjs
+++ b/scripts/new-post.mjs
@@ -60,6 +60,8 @@ function main() {
   console.log("");
   console.log("次のステップ:");
   console.log("  1. frontmatter(title/description/categories等)を編集する");
+  console.log("     ※ categories の仮値 __REPLACE_ME__ は content/categories.json の実在IDに必ず差し替える");
+  console.log("       (先頭要素が公開URL /{locale}/blogs/{category}/{slug} のカテゴリ部分になります)");
   console.log("  2. 本文を執筆する(埋め込みコンポーネントの使い方は docs/writing.md を参照)");
   console.log("  3. `npm run dev` でプレビュー(draft: true の記事は開発環境でのみ表示されます)");
   console.log("  4. 公開準備ができたら draft: false に変更し、PRを作成する");
@@ -68,6 +70,11 @@ function main() {
 }
 
 // ロケール別のfrontmatterテンプレートを生成する
+// NOTE: categoriesの仮値は content/categories.json に存在しないIDにしてある。
+// 以前は `test` だったが、実在カテゴリ「テスト」(旧id: test)と文字列が同一で、
+// 「本物のQA記事」と「差し替え忘れ」が区別できなかった(2026-07-27に実在側を testing へ改名)。
+// veliteのスキーマは categories を素の文字列配列としか検証しないため、この仮値でもビルドは通る。
+// 差し替え忘れは公開URLに `__REPLACE_ME__` がそのまま出るので目視で必ず気付ける。
 function buildFrontmatter({ now, locale }) {
   const title = locale === "ja" ? "(タイトルを入力してください)" : "(Enter title here)";
   const description =
@@ -79,7 +86,7 @@ description: ${description}
 publishedAt: "${now}"
 updatedAt: "${now}"
 categories:
-  - test
+  - __REPLACE_ME__
 draft: true
 ---
 


### PR DESCRIPTION
## 背景

「テスト」カテゴリのIDは `test` でしたが、`npm run new-post` が生成する**仮値プレースホルダーも同じ `test`** でした。そのため `categories: [test]` を見ても「ソフトウェアテストの記事」なのか「カテゴリ差し替え忘れ」なのか判別できませんでした。

velite は `categories` を素の文字列配列としか検証しない(`velite.config.ts`)ため機械検証でも区別できず、実際に執筆ワークフロー側のルール文書が `jstqb-foundation-study-method` を「仮値の残置」と誤認していました。

**この記事の `test` は仮値ではありません。** 2026-07-03 にこの記事のために新設された実在カテゴリのIDで、microCMS 入稿時点(`new-post` が存在しない時期)から意図して設定されていた値です。誤認の原因は仮値と実在カテゴリのIDが偶然同一だったことにあります。

## 変更内容

衝突の**両側**を同時に変更して、以後この曖昧さが発生しないようにします。

| 対象 | 変更前 | 変更後 |
|---|---|---|
| 実在カテゴリのID | `test` | `testing` |
| 実在カテゴリの `name_en` | `test` | `Testing` |
| `new-post` の仮値 | `test` | `__REPLACE_ME__` |

- 日本語の表示名「テスト」は変更していません
- `name_en` は他カテゴリ(Review / Career / Programming)の表記に揃えました
- 仮値 `__REPLACE_ME__` は `categories.json` に存在しないIDなので実カテゴリと絶対に衝突しません。差し替え忘れは公開URLにそのまま出るため目視で気付けます

### リダイレクト

カテゴリIDの変更により `jstqb-foundation-study-method` の公開URLが変わります。

- 変更前: `/{locale}/blogs/test/jstqb-foundation-study-method`
- 変更後: `/{locale}/blogs/testing/jstqb-foundation-study-method`

記事詳細ページは URL のカテゴリセグメントと実カテゴリの不一致を `notFound()` にする実装(`src/app/[locale]/blogs/[category]/[blogId]/page.tsx`)のため、**リダイレクトが無いと旧URLは404になります**。`next.config.mjs` に ja/en・ロケール無し・記事/カテゴリ一覧/ページネーションを網羅した恒久リダイレクトを追加しました。

## 検証

`npm run lint:content` 全項目パス(内部リンク72件・文字化け72件・textlint・markdownlint 0 error・velite build 成功)。

`next dev` で旧URL6形式を実測し、すべて新URLへ到達・遷移先が200であることを確認しました。

```
/ja/blogs/test/jstqb-foundation-study-method  -> 308 /ja/blogs/testing/jstqb-foundation-study-method
/en/blogs/test/jstqb-foundation-study-method  -> 308 /en/blogs/testing/jstqb-foundation-study-method
/ja/blogs/test                                -> 308 /ja/blogs/testing
/en/blogs/test                                -> 308 /en/blogs/testing
/blogs/test/jstqb-foundation-study-method     -> 308 /ja/blogs/testing/jstqb-foundation-study-method
/blogs/test                                   -> 308 /ja/blogs/testing
```

あわせて確認済み:

- sitemap が `blogs/testing` / `blogs/testing/jstqb-foundation-study-method` を出力する(`blogs/test` は消える)
- パンくずの構造化データが「テスト」を保つ
- `content/blogs/` 配下に `- test` を使う記事が他に存在しない

## レビュー時の注意

- ステータスは **301 ではなく 308** です。Next.js の `permanent: true` の仕様で、このリポジトリの既存の恒久リダイレクトもすべて308です。Google は308を301と同等に扱います
- `scripts/migration/` 配下のスナップショットは移行時に実際に取得した出力の記録なので、意図的に更新していません

## マージ後にやること

- GSC で新URL(ja/en)の再申請
- 旧URLのリダイレクト認識の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
