### PR TITLE
fix(mdx): 画像のみの段落からpラッパーを外しhydration警告を解消

### DIFF
--- a/velite.config.ts
+++ b/velite.config.ts
@@ -12,6 +12,7 @@ import { extractPlainText, extractToc } from "./velite/mdast-utils";
 import { rehypeCodeMeta } from "./velite/rehype-code-meta";
 import { rehypeImageSize } from "./velite/rehype-image-size";
 import { rehypeRestoreHeadingIds } from "./velite/rehype-restore-heading-ids";
+import { rehypeUnwrapImages } from "./velite/rehype-unwrap-images";
 
 // 現在パース中のファイルのパス(blogs/{slug}/index.{locale}.mdx)から slug と locale を抽出する
 // (VeliteFile.pathはconfig.rootからの絶対パスのため、まずroot相対パスに正規化してから照合する)
@@ -131,11 +132,11 @@ const categories = defineCollection({
 export default defineConfig({
   collections: { blogs, categories },
   mdx: {
-    // 見出しid復元・画像サイズ注入・codeメタ受け渡し(#236)。
+    // 見出しid復元・画像段落unwrap・画像サイズ注入・codeメタ受け渡し(#236)。
     // 実行順序: rehypePluginsはremark段階(remarkCopyLinkedFiles含む)より後に実行されるため、
     // rehypeImageSizeは画像パスが/static/...へ書き換わった後の状態で実ファイルを解決する
     // (詳細はvelite/rehype-image-size.tsのコメント参照)。
-    rehypePlugins: [rehypeRestoreHeadingIds, rehypeImageSize, rehypeCodeMeta],
+    rehypePlugins: [rehypeRestoreHeadingIds, rehypeUnwrapImages, rehypeImageSize, rehypeCodeMeta],
   },
   // ビルド結果をファイル書き出し前に加工するフック(#240 draft運用)。
   // 本番ビルド(NODE_ENV=production。package.jsonのprebuildが明示的にセットする)でのみ、

--- a/velite/rehype-unwrap-images.test.ts
+++ b/velite/rehype-unwrap-images.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { rehypeUnwrapImages } from "./rehype-unwrap-images";
+
+import type { Element, ElementContent, Root, Text } from "hast";
+
+// テスト用のhastノード生成ヘルパー
+const el = (tagName: string, children: ElementContent[] = []): Element => ({
+  type: "element",
+  tagName,
+  properties: {},
+  children,
+});
+
+const img = (src: string): Element => ({
+  type: "element",
+  tagName: "img",
+  properties: { src },
+  children: [],
+});
+
+const text = (value: string): Text => ({ type: "text", value });
+
+const root = (children: Root["children"]): Root => ({ type: "root", children });
+
+// プラグインを適用して変換後のツリーを返す
+const run = (tree: Root): Root => {
+  rehypeUnwrapImages()(tree);
+  return tree;
+};
+
+describe("rehypeUnwrapImages", () => {
+  it("画像のみの段落からpラッパーを外す", () => {
+    const tree = run(root([el("p", [img("/static/a.png")])]));
+    expect(tree.children).toHaveLength(1);
+    expect((tree.children[0] as Element).tagName).toBe("img");
+  });
+
+  it("複数画像が並ぶ段落(空白テキスト含む)もunwrapする", () => {
+    const tree = run(
+      root([el("p", [img("/static/a.png"), text("\n"), img("/static/b.png")])]),
+    );
+    const tagNames = tree.children
+      .filter((node): node is Element => node.type === "element")
+      .map((node) => node.tagName);
+    expect(tagNames).toEqual(["img", "img"]);
+  });
+
+  it("画像のみを含むリンクだけの段落もunwrapする", () => {
+    const tree = run(
+      root([el("p", [el("a", [img("/static/a.png")])])]),
+    );
+    expect(tree.children).toHaveLength(1);
+    expect((tree.children[0] as Element).tagName).toBe("a");
+  });
+
+  it("テキストと画像が混在する段落は変更しない", () => {
+    const tree = run(
+      root([el("p", [text("説明: "), img("/static/a.png")])]),
+    );
+    expect(tree.children).toHaveLength(1);
+    expect((tree.children[0] as Element).tagName).toBe("p");
+  });
+
+  it("画像を含まない通常の段落は変更しない", () => {
+    const tree = run(root([el("p", [text("ただの文章")])]));
+    expect(tree.children).toHaveLength(1);
+    expect((tree.children[0] as Element).tagName).toBe("p");
+  });
+
+  it("blockquote内など入れ子の画像段落もunwrapする", () => {
+    const tree = run(
+      root([el("blockquote", [el("p", [img("/static/a.png")])])]),
+    );
+    const blockquote = tree.children[0] as Element;
+    expect((blockquote.children[0] as Element).tagName).toBe("img");
+  });
+});

--- a/velite/rehype-unwrap-images.ts
+++ b/velite/rehype-unwrap-images.ts
@@ -1,0 +1,54 @@
+// MDX本文中の「画像のみを含む段落」から<p>ラッパーを外すrehypeプラグイン。
+//
+// なぜ必要か:
+// Markdownの画像("![alt](./images/xxx.jpeg)")は段落として<p>にラップされるが、
+// レンダリング側のMdxImg(src/components/ArticleBody/MdxContent/MdxImg.tsx)は
+// PopupModalの<div>やCustomImgの<p>を描画するため、<p>の子に<div>/<p>が入る
+// 不正なHTMLネストになる(React devオーバーレイのhydration警告・本番HTMLでも不正のまま)。
+// コンポーネント側をphrasing contentに寄せるより、そもそも段落ラッパーを外すほうが
+// 全ケース(PopupModalの二重div・CustomImgのp)を一度に解決できる。
+//
+// unwrap対象は「画像・画像のみを含むリンク・空白テキストだけで構成され、
+// 画像を1枚以上含む段落」(rehype-unwrap-imagesと同等の判定)。
+// テキストと画像が混在する段落は通常の段落として維持する
+// (現状の記事には存在しないことを確認済み。存在しても表示が壊れるわけではない)。
+import { SKIP, visit } from "unist-util-visit";
+
+import type { Element, ElementContent, Root } from "hast";
+
+// 空白のみのテキストノードか
+const isWhitespaceText = (node: ElementContent): boolean =>
+  node.type === "text" && /^[ \t\r\n]*$/.test(node.value);
+
+const isImg = (node: ElementContent): boolean =>
+  node.type === "element" && node.tagName === "img";
+
+// 子が「画像・空白・(画像のみを含む)リンク」だけで構成され、画像を1枚以上含むか
+const containsOnlyImages = (children: ElementContent[]): boolean => {
+  let hasImage = false;
+  for (const child of children) {
+    if (isWhitespaceText(child)) continue;
+    if (isImg(child)) {
+      hasImage = true;
+      continue;
+    }
+    if (child.type === "element" && child.tagName === "a") {
+      if (!containsOnlyImages(child.children)) return false;
+      hasImage = true;
+      continue;
+    }
+    return false;
+  }
+  return hasImage;
+};
+
+export const rehypeUnwrapImages = () => (tree: Root) => {
+  visit(tree, "element", (node: Element, index, parent) => {
+    if (node.tagName !== "p" || index === undefined || !parent) return;
+    if (!containsOnlyImages(node.children)) return;
+
+    parent.children.splice(index, 1, ...node.children);
+    // 展開した子ノードを再訪問する必要はないため、その直後から走査を続行する
+    return [SKIP, index + node.children.length];
+  });
+};


### PR DESCRIPTION
## 概要

MDX記事内の画像1枚ごとにNext.js devオーバーレイへ「In HTML, `<div>` cannot be a descendant of `<p>`. This will cause a hydration error.」が積まれる問題の修正です(best-buy-2026-first-halfで56 issues)。本番ビルドでは警告は出ないものの、不正ネスト自体はHTMLに残っていました。

## 原因

MDXの画像(`![alt](./images/x.jpg)`)は段落として`<p>`にラップされる一方、レンダリング側は:

- `MdxImg` → `PopupModal`が`<div>`を2つ描画(通常表示+モーダル複製)
- さらに`CustomImg`自身も`<p className="flex justify-center my-8">`ラッパーを描画

そのため `p(MDX段落) > div(PopupModal)×2 > p(CustomImg)` という多重の不正ネストになっていました。`PopupModal`のspan化やPortal化では`CustomImg`の`<p>`が残るため、段落ラッパーを外す方式を採用しています。

## 変更内容

- **velite/rehype-unwrap-images.ts(新規)**: 「画像・画像のみを含むリンク・空白テキストだけで構成され、画像を1枚以上含む段落」から`<p>`を外すrehypeプラグイン。既存の`velite/rehype-*.ts`パターンに合わせ依存追加なしで実装(`rehype-unwrap-images`パッケージと同等の判定)。1段落に画像2枚が並ぶ既存記事にも対応
- **velite.config.ts**: `rehypePlugins`へ組み込み
- **velite/rehype-unwrap-images.test.ts(新規)**: 単体テスト6件(単一画像/複数画像+空白/リンク内画像/テキスト混在(対象外)/画像なし(対象外)/blockquote内)

テキストと画像が混在する段落はunwrap対象外として維持します(該当はrelease-notes-202607の挨拶行1箇所のみで、こちらはwidth/height無しの素の`<img>`フォールバックのため元々警告は発生しません)。

## 検証

- devオーバーレイ: 本文画像9枚の記事でissueバッジなし(0 issues)、コンソールに「cannot be a descendant」警告ゼロ
- DOM実測: `p div`・`p p`ともに0件。画像のDOMは `div(PopupModal) > p(CustomImg) > span > img` で全て妥当
- ポップアップ挙動: クリックで開く→Escapeで閉じるをDOMイベントで確認。画像表示も維持
- 全記事のVeliteコンパイル出力で`p`直下のimg描画呼び出しが0件であることを横断確認
- 品質ゲート: lint / tsc --noEmit / vitest(82件) / npm run build(168ページ)すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)