### PR TITLE
fix: hikkoshi-best-buyのA8リンクをMarkdown記法に修正

### DIFF
--- a/content/blogs/hikkoshi-best-buy/index.ja.mdx
+++ b/content/blogs/hikkoshi-best-buy/index.ja.mdx
@@ -209,7 +209,8 @@ moshimoWidgets:
 
 引越し業者はケーエー引越センターを使いました。都内の近距離で荷物も少なめだったので、訪問見積もりなしでメールと電話だけで完結する格安業者にした形です。
 
-<a href="https://px.a8.net/svt/ejp?a8mat=4BA7X6+CQFSKY+5UYQ+5YJRM" rel="nofollow">単身引越しに特化した大人気の安心サービス！【ケーエー引越センター】</a>
+[単身引越しに特化した大人気の安心サービス！【ケーエー引越センター】](https://px.a8.net/svt/ejp?a8mat=4BA7X6+CQFSKY+5UYQ+5YJRM)
+
 <img border="0" width="1" height="1" src="https://www12.a8.net/0.gif?a8mat=4BA7X6+CQFSKY+5UYQ+5YJRM" alt="" />
 
 流れはこんな感じでした。
@@ -254,7 +255,8 @@ moshimoWidgets:
 
 新居の光回線はGMOとくとくBB光にしました。
 
-<a href="https://px.a8.net/svt/ejp?a8mat=4BA7X6+CPUCZ6+50+6M7QUQ" rel="nofollow">シンプルに安い速いGMOとくとくBB光！高性能なWi-Fiルーターレンタル無料！</a>
+[シンプルに安い速いGMOとくとくBB光！高性能なWi-Fiルーターレンタル無料！](https://px.a8.net/svt/ejp?a8mat=4BA7X6+CPUCZ6+50+6M7QUQ)
+
 <img border="0" width="1" height="1" src="https://www15.a8.net/0.gif?a8mat=4BA7X6+CPUCZ6+50+6M7QUQ" alt="" />
 
 引っ越しで意外と忘れがちなのが回線の手配です。工事が必要なケースだと申し込みから開通まで数週間かかるので、うちは入居3週間前の4月頭に申し込んでおきました。


### PR DESCRIPTION
生JSXの<a>タグはMdxLinkマッピングを通らず無装飾の黒文字で表示されていたため、Markdownリンク記法に変更(ExternalLinkの下線スタイルが適用される)。計測ビーコンは維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)